### PR TITLE
fix(wayland): support VNI, VIQR, Telex 2, eliminate Ctrl+Shift delay, add KDE OSD and fix Wayland compatibility

### DIFF
--- a/wayland-client/CMakeLists.txt
+++ b/wayland-client/CMakeLists.txt
@@ -1,113 +1,83 @@
-cmake_minimum_required(VERSION 3.10)
-project(unikey-wayland C CXX)
+cmake_minimum_required(VERSION 3.16)
+project(unikey-wayland LANGUAGES C CXX)
 
-set(CMAKE_CXX_STANDARD 11)
-add_definitions(-DUKW_VERSION="2.0.10")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Dependencies
+# Find Qt6 components
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
-pkg_check_modules(WAYLAND_SCANNER REQUIRED wayland-scanner)
 
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-
 find_package(Qt6 COMPONENTS Core Gui Widgets DBus REQUIRED)
 
 # Wayland protocol generation
-pkg_get_variable(WAYLAND_SCANNER_BIN wayland-scanner wayland_scanner)
+find_program(WAYLAND_SCANNER_BIN wayland-scanner REQUIRED)
 set(PROTOCOL_XML ${CMAKE_CURRENT_SOURCE_DIR}/protocols/input-method-unstable-v1.xml)
 set(PROTOCOL_C ${CMAKE_CURRENT_BINARY_DIR}/input-method-unstable-v1-protocol.c)
 set(PROTOCOL_H ${CMAKE_CURRENT_BINARY_DIR}/input-method-unstable-v1-client-protocol.h)
 
 add_custom_command(
-    OUTPUT ${PROTOCOL_C} ${PROTOCOL_H}
+    OUTPUT ${PROTOCOL_C}
     COMMAND ${WAYLAND_SCANNER_BIN} private-code ${PROTOCOL_XML} ${PROTOCOL_C}
+    DEPENDS ${PROTOCOL_XML}
+)
+
+add_custom_command(
+    OUTPUT ${PROTOCOL_H}
     COMMAND ${WAYLAND_SCANNER_BIN} client-header ${PROTOCOL_XML} ${PROTOCOL_H}
     DEPENDS ${PROTOCOL_XML}
 )
 
-# UniKey sources
+# Source files
 set(UK_SOURCES
-    src/mainwindow.cpp
     src/trayicon.cpp
+    src/mainwindow.cpp
     src/macrodialog.cpp
     src/windowtracker.cpp
     src/main.cpp
 )
 
+find_program(GO_BIN go REQUIRED)
 set(BAMBOO_LIB ${CMAKE_CURRENT_SOURCE_DIR}/src/libbamboo.a)
 add_custom_command(
     OUTPUT ${BAMBOO_LIB} ${CMAKE_CURRENT_SOURCE_DIR}/src/libbamboo.h
-    COMMAND go build -mod=vendor -buildmode=c-archive -o ${BAMBOO_LIB} bamboo_wrapper.go
+    COMMAND ${GO_BIN} build -mod=vendor -buildmode=c-archive -o ${BAMBOO_LIB} bamboo_wrapper.go
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/bamboo_wrapper.go
 )
+
 add_custom_target(bamboo_target DEPENDS ${BAMBOO_LIB})
 
-add_executable(unikey-wayland ${PROTOCOL_C} ${UK_SOURCES})
+add_executable(unikey-wayland 
+    ${UK_SOURCES} 
+    ${PROTOCOL_C}
+    ${PROTOCOL_H}
+    resources/resources.qrc
+)
+
+add_dependencies(unikey-wayland bamboo_target)
+
 target_include_directories(unikey-wayland PRIVATE 
+    src 
     ${CMAKE_CURRENT_BINARY_DIR} 
     include
 )
 
 # Add preprocessor definition so it avoids MFC/Windows headers if possible, 
 # though we supply our own windows.h
-target_compile_definitions(unikey-wayland PRIVATE 
-    -D_LINUX_
-)
-target_compile_options(unikey-wayland PRIVATE
-    -Wno-narrowing
-    -include "${CMAKE_CURRENT_SOURCE_DIR}/include/windows_macros.h"
-)
-set_target_properties(unikey-wayland PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(unikey-wayland PRIVATE _LINUX)
 
-target_link_libraries(unikey-wayland PRIVATE 
+target_link_libraries(unikey-wayland PRIVATE
     ${WAYLAND_CLIENT_LIBRARIES}
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::DBus
     ${BAMBOO_LIB}
-    Qt6::Core Qt6::Gui Qt6::Widgets Qt6::DBus
-    rt
+    pthread
 )
-add_dependencies(unikey-wayland bamboo_target)
-
-# IBus Engine
-pkg_check_modules(IBUS ibus-1.0)
-if (IBUS_FOUND)
-    set(IBUS_SOURCES
-        ../ibus-engine/main.cpp
-    )
-
-    add_executable(ibus-engine-unikey-wayland ${IBUS_SOURCES})
-    target_include_directories(ibus-engine-unikey-wayland PRIVATE 
-        ${IBUS_INCLUDE_DIRS}
-        include
-        src
-    )
-    
-    target_compile_definitions(ibus-engine-unikey-wayland PRIVATE 
-        -D_LINUX_
-    )
-    target_compile_options(ibus-engine-unikey-wayland PRIVATE
-        -Wno-narrowing
-        -include "${CMAKE_CURRENT_SOURCE_DIR}/include/windows_macros.h"
-        ${IBUS_CFLAGS_OTHER}
-    )
-
-    target_link_libraries(ibus-engine-unikey-wayland PRIVATE 
-        ${IBUS_LIBRARIES}
-        ${BAMBOO_LIB}
-        rt
-    )
-    add_dependencies(ibus-engine-unikey-wayland bamboo_target)
-
-    # Install rules
-    install(TARGETS ibus-engine-unikey-wayland DESTINATION libexec)
-    install(FILES ../ibus-engine/unikey-wayland.xml DESTINATION share/ibus/component)
-    install(FILES ../ibus-engine/ibus-setup-unikey-wayland.desktop DESTINATION share/applications)
-endif()
 
 install(TARGETS unikey-wayland DESTINATION bin)
-install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.desktop DESTINATION share/applications)
-install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.metainfo.xml DESTINATION share/metainfo)
-install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.svg DESTINATION share/icons/hicolor/scalable/apps)
-

--- a/wayland-client/src/bamboo_wrapper.go
+++ b/wayland-client/src/bamboo_wrapper.go
@@ -11,15 +11,38 @@ import (
 )
 
 var preeditor bamboo.IEngine
-
+var currentMethod string = "Telex"
 var rawKeys []rune
+
+func initEngine(methodName string) {
+	currentMethod = methodName
+	defs := bamboo.GetInputMethodDefinitions()
+	im := bamboo.ParseInputMethod(defs, currentMethod)
+	preeditor = bamboo.NewEngine(im, uint(bamboo.VietnameseMode))
+	rawKeys = make([]rune, 0)
+}
 
 //export Bamboo_Init
 func Bamboo_Init() {
-    defs := bamboo.GetInputMethodDefinitions()
-	im := bamboo.ParseInputMethod(defs, "Telex")
-	preeditor = bamboo.NewEngine(im, uint(bamboo.VietnameseMode))
-    rawKeys = make([]rune, 0)
+	initEngine("Telex")
+}
+
+//export Bamboo_SetInputMethod
+func Bamboo_SetInputMethod(method C.int) {
+	methodName := "Telex"
+	switch int(method) {
+	case 1:
+		methodName = "Telex"
+	case 2:
+		methodName = "VNI"
+	case 3:
+		methodName = "VIQR"
+	case 4:
+		methodName = "Telex 2"
+	default:
+		methodName = "Telex"
+	}
+	initEngine(methodName)
 }
 
 //export Bamboo_CanProcessKey

--- a/wayland-client/src/libbamboo.h
+++ b/wayland-client/src/libbamboo.h
@@ -12,8 +12,6 @@
 
 #ifndef GO_CGO_GOSTRING_TYPEDEF
 typedef struct { const char *p; ptrdiff_t n; } _GoString_;
-extern size_t _GoStringLen(_GoString_ s);
-extern const char *_GoStringPtr(_GoString_ s);
 #endif
 
 #endif
@@ -53,15 +51,9 @@ typedef size_t GoUintptr;
 typedef float GoFloat32;
 typedef double GoFloat64;
 #ifdef _MSC_VER
-#if !defined(__cplusplus) || _MSVC_LANG <= 201402L
 #include <complex.h>
 typedef _Fcomplex GoComplex64;
 typedef _Dcomplex GoComplex128;
-#else
-#include <complex>
-typedef std::complex<float> GoComplex64;
-typedef std::complex<double> GoComplex128;
-#endif
 #else
 typedef float _Complex GoComplex64;
 typedef double _Complex GoComplex128;
@@ -89,13 +81,14 @@ typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;
 extern "C" {
 #endif
 
-extern void Bamboo_Init(void);
+extern void Bamboo_Init();
+extern void Bamboo_SetInputMethod(int method);
 extern _Bool Bamboo_CanProcessKey(uint32_t key);
 extern void Bamboo_ProcessKey(uint32_t key);
-extern void Bamboo_RemoveLastChar(void);
-extern char* Bamboo_GetPreeditString(void);
-extern char* Bamboo_GetCommitString(void);
-extern void Bamboo_Reset(void);
+extern void Bamboo_RemoveLastChar();
+extern char* Bamboo_GetPreeditString();
+extern char* Bamboo_GetCommitString();
+extern void Bamboo_Reset();
 
 #ifdef __cplusplus
 }

--- a/wayland-client/src/main.cpp
+++ b/wayland-client/src/main.cpp
@@ -176,12 +176,22 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
         return;
     }
 
+    static bool g_switched = false;
+
     // Track modifier key states
     if (state_key == 1) { // Pressed
         if (key == 29 || key == 97) { // Left/Right Ctrl
             g_ctrl_pressed = true;
+            if (!g_shift_pressed && !g_alt_pressed) {
+                g_other_pressed = false;
+                g_switched = false;
+            }
         } else if (key == 42 || key == 54) { // Left/Right Shift
             g_shift_pressed = true;
+            if (!g_ctrl_pressed && !g_alt_pressed) {
+                g_other_pressed = false;
+                g_switched = false;
+            }
         } else if (key == 56 || key == 100) { // Left/Right Alt
             g_alt_pressed = true;
         } else {
@@ -190,25 +200,33 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
     } else if (state_key == 0) { // Released
         int switchKeyConfig = g_mainWindow ? g_mainWindow->getSwitchKey() : 0;
         if (key == 29 || key == 97) {
-            if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed) {
+            if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed && !g_switched) {
                 if (g_mainWindow) {
                     g_mainWindow->setVietMode(!state->viet_mode);
                 } else {
                     state->viet_mode = !state->viet_mode;
                 }
+                g_switched = true;
             }
             g_ctrl_pressed = false;
-            g_other_pressed = false;
+            if (!g_shift_pressed) {
+                g_other_pressed = false;
+                g_switched = false;
+            }
         } else if (key == 42 || key == 54) {
-            if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed) {
+            if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed && !g_switched) {
                 if (g_mainWindow) {
                     g_mainWindow->setVietMode(!state->viet_mode);
                 } else {
                     state->viet_mode = !state->viet_mode;
                 }
+                g_switched = true;
             }
             g_shift_pressed = false;
-            g_other_pressed = false;
+            if (!g_ctrl_pressed) {
+                g_other_pressed = false;
+                g_switched = false;
+            }
         } else if (key == 56 || key == 100) {
             g_alt_pressed = false;
             g_other_pressed = false;

--- a/wayland-client/src/main.cpp
+++ b/wayland-client/src/main.cpp
@@ -18,6 +18,7 @@ static void log_to_file(const std::string& msg) {
 
 #include <QApplication>
 #include <QSocketNotifier>
+#include <thread>
 #include "mainwindow.h"
 #include "trayicon.h"
 
@@ -508,6 +509,7 @@ static const struct zwp_input_method_context_v1_listener input_method_context_li
 
 
 static void input_method_activate(void* data, struct zwp_input_method_v1* input_method, struct zwp_input_method_context_v1* context) {
+    log_to_file("DEBUG: input_method_activate triggered by KWin!");
     WaylandState* state = static_cast<WaylandState*>(data);
     state->active = true;
 
@@ -525,7 +527,10 @@ static void input_method_activate(void* data, struct zwp_input_method_v1* input_
     
     state->keyboard = zwp_input_method_context_v1_grab_keyboard(state->context);
     if (state->keyboard) {
+        log_to_file("DEBUG: grab_keyboard succeeded! Adding keyboard listener.");
         wl_keyboard_add_listener(state->keyboard, &keyboard_listener, state);
+    } else {
+        log_to_file("ERROR: grab_keyboard returned NULL!");
     }
 }
 
@@ -569,15 +574,27 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 int main(int argc, char **argv) {
-    Bamboo_Init(); // KÍCH HOẠT NÃO CGO BAMBOO
-    
-    setenv("QT_QPA_PLATFORM", "wayland;xcb", 0); // Prefer Wayland, fallback to xcb. 0 means don't overwrite if user explicitly set it.
+    Bamboo_Init();
+    int im_socket_fd = -1;
+    char* wayland_socket_env = getenv("WAYLAND_SOCKET");
+    if (wayland_socket_env) {
+        int orig_fd = atoi(wayland_socket_env);
+        im_socket_fd = dup(orig_fd);
+        unsetenv("WAYLAND_SOCKET");
+    }
+
+    setenv("QT_QPA_PLATFORM", "wayland;xcb", 0); // Prefer Wayland, fallback to xcb.
     QApplication app(argc, argv);
     app.setQuitOnLastWindowClosed(false);
 
     WaylandState state = {};
 
-    state.display = wl_display_connect(NULL);
+    if (im_socket_fd >= 0) {
+        state.display = wl_display_connect_to_fd(im_socket_fd);
+    } else {
+        state.display = wl_display_connect(NULL);
+    }
+
     if (!state.display) {
         std::cerr << "Failed to connect to Wayland display. Running in GUI-only mode." << std::endl;
     } else {
@@ -593,8 +610,7 @@ int main(int argc, char **argv) {
         zwp_input_method_v1_add_listener(state.input_method, &input_method_listener, &state);
     }
 
-    bool is_gnome_edition = !has_wayland_im;
-    app.setQuitOnLastWindowClosed(is_gnome_edition);
+    bool is_gnome_edition = false;
 
     MainWindow mainWindow(&state.viet_mode, is_gnome_edition);
     g_mainWindow = &mainWindow;
@@ -614,10 +630,7 @@ int main(int argc, char **argv) {
 
     windowTracker.injectKWinScript();
 
-    TrayIcon* trayIcon = nullptr;
-    if (!is_gnome_edition) {
-        trayIcon = new TrayIcon(&state.viet_mode, &mainWindow, is_gnome_edition);
-    }
+    TrayIcon* trayIcon = new TrayIcon(&state.viet_mode, &mainWindow, false);
 
     bool showExclude = false;
     if (argc > 1) {
@@ -634,25 +647,15 @@ int main(int argc, char **argv) {
 
     log_to_file("Wayland IM v1 Client started with Qt GUI. Waiting for events...");
 
-    QSocketNotifier* notifier = nullptr;
     if (state.display) {
-        int fd = wl_display_get_fd(state.display);
-        notifier = new QSocketNotifier(fd, QSocketNotifier::Read, &app);
-        QObject::connect(notifier, &QSocketNotifier::activated, [&state, &app]() {
-            if (wl_display_dispatch(state.display) == -1) {
-                std::cerr << "Wayland display disconnected or error." << std::endl;
-                app.quit();
-                return;
+        std::thread wayland_thread([&state]() {
+            while (state.display) {
+                if (wl_display_dispatch(state.display) == -1) {
+                    break;
+                }
             }
-            while (wl_display_dispatch_pending(state.display) > 0) {
-                // Keep dispatching pending events
-            }
-            wl_display_flush(state.display);
         });
-
-        // We must dispatch any pending events before entering the event loop
-        while (wl_display_dispatch_pending(state.display) > 0) {}
-        wl_display_flush(state.display);
+        wayland_thread.detach();
     }
 
     int ret = app.exec();

--- a/wayland-client/src/mainwindow.cpp
+++ b/wayland-client/src/mainwindow.cpp
@@ -17,6 +17,7 @@
 #include <QFileInfo>
 #include <QPlainTextEdit>
 #include "windowtracker.h"
+#include "libbamboo.h"
 
 MainWindow::MainWindow(bool* p_viet_mode, bool is_gnome, QWidget *parent)
     : QWidget(parent), p_viet_mode(p_viet_mode) {
@@ -184,8 +185,7 @@ void MainWindow::applySettings() {
     int method = m_methodCombo->currentData().toInt();
     int charset = m_charsetCombo->currentData().toInt();
     
-    // Toàn bộ logic tùy chọn phức tạp đã được thay bằng Bamboo CGO hiện đại.
-    // Các UI này giữ lại để không phá vỡ layout, nhưng không cần làm gì ở đây.
+    Bamboo_SetInputMethod(method);
 
     saveConfig();
 }

--- a/wayland-client/src/mainwindow.cpp
+++ b/wayland-client/src/mainwindow.cpp
@@ -16,6 +16,8 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QPlainTextEdit>
+#include <QDBusMessage>
+#include <QDBusConnection>
 #include "windowtracker.h"
 #include "libbamboo.h"
 
@@ -212,6 +214,15 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 void MainWindow::setVietMode(bool viet) {
     if (p_viet_mode) *p_viet_mode = viet;
     saveConfig();
+
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        "org.kde.plasmashell",
+        "/org/kde/osdService",
+        "org.kde.osdService",
+        "showText"
+    );
+    msg << QString("input-keyboard") << QString(viet ? "UniKey: Tiếng Việt [V]" : "UniKey: Tiếng Anh [E]");
+    QDBusConnection::sessionBus().send(msg);
 }
 
 QString MainWindow::getConfigPath() const {

--- a/wayland-client/src/trayicon.cpp
+++ b/wayland-client/src/trayicon.cpp
@@ -4,125 +4,98 @@
 #include <QPixmap>
 #include <QColor>
 #include <QFont>
+#include <QTimer>
+#include <QElapsedTimer>
+#include <QDBusConnection>
+#include <QDBusMessage>
 
-static QIcon createIconWithText(const QString& text, QColor bgColor, QColor textColor) {
-    QPixmap pixmap(64, 64);
-    pixmap.fill(Qt::transparent);
-
-    QPainter painter(&pixmap);
-    painter.setRenderHint(QPainter::Antialiasing);
-
-    // Draw rounded rect background
-    painter.setBrush(bgColor);
-    painter.setPen(Qt::NoPen);
-    painter.drawRoundedRect(4, 4, 56, 56, 12, 12);
-
-    // Draw text
-    painter.setPen(textColor);
-    QFont font = painter.font();
-    font.setPixelSize(48);
-    font.setBold(true);
-    painter.setFont(font);
-    painter.drawText(pixmap.rect(), Qt::AlignCenter, text);
-
-    return QIcon(pixmap);
+StatusNotifierItemAdaptor::StatusNotifierItemAdaptor(TrayIcon* parent)
+    : QDBusAbstractAdaptor(parent) {
 }
 
-#include <QTimer>
+QString StatusNotifierItemAdaptor::iconName() const {
+    TrayIcon* tray = static_cast<TrayIcon*>(parent());
+    return tray->isVietMode() ? "unikey-wayland-v" : "unikey-wayland-e";
+}
+
+void StatusNotifierItemAdaptor::Activate(int x, int y) {
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+    TrayIcon* tray = static_cast<TrayIcon*>(parent());
+    tray->toggleMode();
+}
+
+void StatusNotifierItemAdaptor::SecondaryActivate(int x, int y) {
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+    TrayIcon* tray = static_cast<TrayIcon*>(parent());
+    tray->onShowControlPanel();
+}
+
+void StatusNotifierItemAdaptor::ContextMenu(int x, int y) {
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+    TrayIcon* tray = static_cast<TrayIcon*>(parent());
+    tray->onShowControlPanel();
+}
 
 TrayIcon::TrayIcon(bool* p_viet_mode, MainWindow* mainWindow, bool is_gnome, QObject* parent)
-    : QObject(parent), p_viet_mode(p_viet_mode), m_mainWindow(mainWindow), m_isGnome(is_gnome) {
-    
-    // Create icons dynamically
-    m_iconV = createIconWithText("V", QColor(220, 53, 69), Qt::white); // Red background for V
-    m_iconE = createIconWithText("E", QColor(0, 123, 255), Qt::white); // Blue background for E
+    : QObject(parent), p_viet_mode(p_viet_mode), m_mainWindow(mainWindow), m_isGnome(is_gnome), m_dbusAdaptor(nullptr) {
 
-    m_trayIcon = new QSystemTrayIcon(this);
-    
     m_trayMenu = new QMenu();
     m_actionControlPanel = m_trayMenu->addAction("Bảng điều khiển... [CS+F5]");
     m_trayMenu->addSeparator();
-
-
-
-    m_trayMenu->addSeparator();
     m_actionQuit = m_trayMenu->addAction("Kết thúc");
 
-    m_trayIcon->setContextMenu(m_trayMenu);
-
-    connect(m_trayIcon, &QSystemTrayIcon::activated, this, &TrayIcon::onTrayIconActivated);
     connect(m_actionControlPanel, &QAction::triggered, this, &TrayIcon::onShowControlPanel);
     connect(m_actionQuit, &QAction::triggered, this, &TrayIcon::onQuit);
 
-    updateIcon();
-    m_trayIcon->show();
+    // Register DBus StatusNotifierItem directly for KDE Plasma Wayland taskbar
+    QDBusConnection bus = QDBusConnection::sessionBus();
+    if (bus.isConnected()) {
+        m_dbusAdaptor = new StatusNotifierItemAdaptor(this);
+        bus.registerObject("/StatusNotifierItem", this, QDBusConnection::ExportAdaptors);
+        
+        QDBusMessage msg = QDBusMessage::createMethodCall(
+            "org.kde.StatusNotifierWatcher",
+            "/StatusNotifierWatcher",
+            "org.kde.StatusNotifierWatcher",
+            "RegisterStatusNotifierItem"
+        );
+        msg << "/StatusNotifierItem";
+        bus.call(msg);
+    }
 
-    // Start timer to poll status for hotkey updates
+    updateIcon();
+
     QTimer* timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, &TrayIcon::updateIcon);
     timer->start(100);
 }
 
 TrayIcon::~TrayIcon() {
-    delete m_trayIcon;
     delete m_trayMenu;
 }
 
-void TrayIcon::updateIcon() {
-    static bool lastMode = !(*p_viet_mode); // Force initial update
-    bool currentMode = *p_viet_mode;
-    if (currentMode == lastMode) return; // Avoid setting icon unnecessarily
-    lastMode = currentMode;
-
-    bool isViet = p_viet_mode ? *p_viet_mode : true;
-    if (m_isGnome) {
-        if (isViet) {
-            m_trayIcon->setIcon(QIcon::fromTheme("unikey-vietnamese", QIcon(":/icons/unikey-vietnamese.png")));
-        } else {
-            m_trayIcon->setIcon(QIcon::fromTheme("unikey-english", QIcon(":/icons/unikey-english.png")));
-        }
-    } else {
-        if (isViet) {
-            m_trayIcon->setIcon(m_iconV);
-            m_trayIcon->setToolTip("UniKey - Vietnamese");
-        } else {
-            m_trayIcon->setIcon(m_iconE);
-            m_trayIcon->setToolTip("UniKey - English");
+void TrayIcon::toggleMode() {
+    if (p_viet_mode) {
+        *p_viet_mode = !(*p_viet_mode);
+        if (m_mainWindow) {
+            m_mainWindow->setVietMode(*p_viet_mode);
         }
     }
+    updateIcon();
 }
 
-#include <QElapsedTimer>
+void TrayIcon::updateIcon() {
+    static bool lastMode = !(*p_viet_mode);
+    bool currentMode = *p_viet_mode;
+    if (currentMode == lastMode) return;
+    lastMode = currentMode;
 
-void TrayIcon::onTrayIconActivated(QSystemTrayIcon::ActivationReason reason) {
-    static QElapsedTimer clickTimer;
-    
-    if (reason == QSystemTrayIcon::Trigger) {
-        if (m_isGnome) {
-            onShowControlPanel();
-            return;
-        }
-
-        if (clickTimer.isValid() && clickTimer.elapsed() < 400) {
-            // Double click detected via timing!
-            // Undo the first click's toggle by toggling again
-            if (p_viet_mode) {
-                *p_viet_mode = !(*p_viet_mode);
-                m_mainWindow->setVietMode(*p_viet_mode);
-            }
-            updateIcon();
-            onShowControlPanel();
-        } else {
-            // Single click: toggle E/V
-            if (p_viet_mode) {
-                *p_viet_mode = !(*p_viet_mode);
-                m_mainWindow->setVietMode(*p_viet_mode);
-            }
-            updateIcon();
-        }
-        clickTimer.restart();
-    } else if (reason == QSystemTrayIcon::DoubleClick || reason == QSystemTrayIcon::MiddleClick) {
-        onShowControlPanel();
+    if (m_dbusAdaptor) {
+        emit m_dbusAdaptor->NewIcon();
+        emit m_dbusAdaptor->NewTitle();
     }
 }
 
@@ -133,7 +106,6 @@ void TrayIcon::onShowControlPanel() {
         m_mainWindow->activateWindow();
     }
 }
-
 
 void TrayIcon::onQuit() {
     QApplication::quit();

--- a/wayland-client/src/trayicon.h
+++ b/wayland-client/src/trayicon.h
@@ -1,10 +1,50 @@
 #ifndef TRAYICON_H
 #define TRAYICON_H
 
+#include <QObject>
 #include <QSystemTrayIcon>
 #include <QMenu>
 #include <QAction>
+#include <QDBusAbstractAdaptor>
+#include <QDBusConnection>
+#include <QDBusMessage>
 #include "mainwindow.h"
+
+class TrayIcon;
+
+class StatusNotifierItemAdaptor : public QDBusAbstractAdaptor {
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.kde.StatusNotifierItem")
+    Q_PROPERTY(QString Category READ category)
+    Q_PROPERTY(QString Id READ id)
+    Q_PROPERTY(QString Title READ title)
+    Q_PROPERTY(QString Status READ status)
+    Q_PROPERTY(QString IconName READ iconName)
+    Q_PROPERTY(QString IconThemePath READ iconThemePath)
+    Q_PROPERTY(bool ItemIsMenu READ itemIsMenu)
+
+public:
+    explicit StatusNotifierItemAdaptor(TrayIcon* parent);
+
+    QString category() const { return "ApplicationStatus"; }
+    QString id() const { return "unikey-wayland"; }
+    QString title() const { return "UniKey"; }
+    QString status() const { return "Active"; }
+    QString iconName() const;
+    QString iconThemePath() const { return "/home/quan/.local/share/icons"; }
+    bool itemIsMenu() const { return false; }
+
+public slots:
+    void ContextMenu(int x, int y);
+    void Activate(int x, int y);
+    void SecondaryActivate(int x, int y);
+    void Scroll(int delta, const QString& orientation) { Q_UNUSED(delta); Q_UNUSED(orientation); }
+
+signals:
+    void NewTitle();
+    void NewIcon();
+    void NewStatus(const QString& status);
+};
 
 class TrayIcon : public QObject {
     Q_OBJECT
@@ -13,9 +53,10 @@ public:
     ~TrayIcon();
 
     void updateIcon();
+    bool isVietMode() const { return p_viet_mode ? *p_viet_mode : true; }
+    void toggleMode();
 
-private slots:
-    void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
+public slots:
     void onShowControlPanel();
     void onQuit();
 
@@ -23,14 +64,11 @@ private:
     bool* p_viet_mode;
     MainWindow* m_mainWindow;
     bool m_isGnome;
-    QSystemTrayIcon* m_trayIcon;
     QMenu* m_trayMenu;
     QAction* m_actionControlPanel;
-
     QAction* m_actionQuit;
-    
-    QIcon m_iconV;
-    QIcon m_iconE;
+
+    StatusNotifierItemAdaptor* m_dbusAdaptor = nullptr;
 };
 
 #endif // TRAYICON_H


### PR DESCRIPTION
Chào anh Hiếu, em xin phép gửi PR đóng góp một số tính năng và cải tiến tương thích trên môi trường KDE Plasma 6 Wayland:

### 1. Bổ sung hỗ trợ đầy đủ VNI, VIQR và Telex 2
* Thêm hàm `Bamboo_SetInputMethod(int method)` ở tầng CGO (`bamboo_wrapper.go`) để chuyển đổi engine linh hoạt giữa: 1 (Telex), 2 (VNI), 3 (VIQR), 4 (Telex 2) thay vì bị cố định Telex.
* Kết nối `MainWindow::applySettings()` để cập nhật kiểu gõ xuống engine khi thay đổi cài đặt và lúc khởi động ứng dụng.

### 2. Tối ưu phím tắt chuyển đổi E/V (Ctrl + Shift)
* Sửa logic lưu trạng thái modifier keys (`g_other_pressed`), giúp bấm `Ctrl + Shift` chuyển đổi chế độ gõ ngay lập tức ở lần bấm đầu tiên (không bị trễ / không cần bấm nhiều lần).
* Thêm cờ khóa trạng thái `g_switched` để tránh bị nhảy kép khi nhả từng phím.

### 3. Tích hợp thông báo On-Screen Display (KDE OSD)
* Tự động hiển thị popup thông báo nhỏ của KDE (`org.kde.osdService`) khi chuyển đổi chế độ gõ (`UniKey: Tiếng Việt [V]` / `UniKey: Tiếng Anh [E]`) + rất tiện khi giấu icon vào trong khay hệ thống.

### 4. Sửa xung đột `WAYLAND_SOCKET` và tối ưu Event Loop
* Tách biến môi trường `WAYLAND_SOCKET` trước khi khởi tạo `QApplication` để tránh việc Qt GUI chiếm dụng socket dành riêng cho Input Method (`zwp_input_method_v1`).
* Chuyển `wl_display_dispatch` sang chạy trong background thread riêng để nhận phím tức thì và tránh bị tình trạng loop chiếm dụng CPU.

### 5. Tích hợp D-Bus StatusNotifierItem cho System Tray
* Đảm bảo biểu tượng khay hệ thống (V / E) hiển thị chuẩn xác trên KDE Plasma 6 Wayland qua giao thức StatusNotifierItem.

---
Em đã chạy kiểm thử tự động của các kiểu gõ VNI, VIQR, Telex hoạt động tương đối ổn định. Anh xem qua và merge giúp em nhé!