### PR TITLE
feat(wayland): hỗ trợ đầy đủ input method, tối ưu Ctrl+Shift, KDE OSD, fix đặt dấu òa/uý, fix gạch chân VS Code & script install.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ arch_pkg/
 *.a
 *.so
 *~
+wayland-client/src/moc_*.cpp
+wayland-client/src/input-method-unstable-v1-protocol.c
+wayland-client/include/input-method-unstable-v1-client-protocol.h
+

--- a/ibus-engine/main.cpp
+++ b/ibus-engine/main.cpp
@@ -8,18 +8,59 @@
 #include <cstdio>
 #include <memory>
 #include <array>
+#include <cstdlib>
+#include <cstring>
 
 #include "libbamboo.h"
 
 static bool g_macroEnabled = false;
 static std::map<std::string, std::string> g_macros;
 
+static bool debug_enabled() {
+    static const bool enabled = [] {
+        const char* value = getenv("UNIKEY_WAYLAND_DEBUG");
+        return value && strcmp(value, "0") != 0;
+    }();
+    return enabled;
+}
+
+static std::string bamboo_string(bool final) {
+    char *value = final ? Bamboo_GetCommitString() : Bamboo_GetPreeditString();
+    std::string result = value ? value : "";
+    if (value) free(value);
+    return result;
+}
+
 struct DelayedCommitData {
     IBusEngine *engine;
     std::string text;
 };
 
-static guint g_focus_out_timer_id = 0;
+static bool json_bool(const std::string& json, const std::string& key, bool fallback) {
+    const size_t key_pos = json.find("\"" + key + "\"");
+    if (key_pos == std::string::npos) return fallback;
+    const size_t colon = json.find(':', key_pos);
+    if (colon == std::string::npos) return fallback;
+    const size_t value = json.find_first_not_of(" \t\r\n", colon + 1);
+    if (value == std::string::npos) return fallback;
+    if (json.compare(value, 4, "true") == 0) return true;
+    if (json.compare(value, 5, "false") == 0) return false;
+    return fallback;
+}
+
+static int json_int(const std::string& json, const std::string& key, int fallback) {
+    const size_t key_pos = json.find("\"" + key + "\"");
+    if (key_pos == std::string::npos) return fallback;
+    const size_t colon = json.find(':', key_pos);
+    if (colon == std::string::npos) return fallback;
+    const size_t value = json.find_first_of("-0123456789", colon + 1);
+    if (value == std::string::npos) return fallback;
+    try {
+        return std::stoi(json.substr(value));
+    } catch (...) {
+        return fallback;
+    }
+}
 
 static gboolean commit_delayed_cb(gpointer user_data) {
     DelayedCommitData *data = static_cast<DelayedCommitData *>(user_data);
@@ -40,6 +81,12 @@ static void reload_macros() {
     std::ifstream f(path);
     if (!f.is_open()) return;
     std::string json((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    Bamboo_SetInputMethod(json_int(json, "method", 1));
+    Bamboo_SetOptions(json_bool(json, "freeMarking", true),
+                      json_bool(json, "modernStyle", false),
+                      json_bool(json, "spellCheck", false),
+                      json_bool(json, "autoRestore", false));
     
     if (json.find("\"macroEnabled\": true") != std::string::npos || json.find("\"macroEnabled\":true") != std::string::npos) {
         g_macroEnabled = true;
@@ -99,6 +146,31 @@ struct _IBusUnikeyEngine {
 struct _IBusUnikeyEngineClass {
     IBusEngineClass parent;
 };
+
+// Bamboo state is shared by all IBus engine objects.
+static guint g_focus_out_timer_id = 0;
+
+static void delete_composition_and_selection(IBusEngine *engine_base,
+                                             IBusUnikeyEngine *engine,
+                                             guint composition_chars) {
+    if (composition_chars == 0) return;
+
+    gint offset = -static_cast<gint>(composition_chars);
+    guint count = composition_chars;
+    if (engine->has_surrounding_text) {
+        const guint selection_start = std::min(engine->surrounding_cursor,
+                                               engine->surrounding_anchor);
+        const guint selection_end = std::max(engine->surrounding_cursor,
+                                             engine->surrounding_anchor);
+        if (composition_chars <= selection_start) {
+            const guint start = selection_start - composition_chars;
+            offset = static_cast<gint>(start) -
+                     static_cast<gint>(engine->surrounding_cursor);
+            count = selection_end - start;
+        }
+    }
+    ibus_engine_delete_surrounding_text(engine_base, offset, count);
+}
 
 GType ibus_unikey_engine_get_type (void);
 
@@ -252,7 +324,10 @@ static void ibus_unikey_engine_focus_in_id (IBusEngine *engine_base, const gchar
     // We intentionally DO NOT call ibus_unikey_engine_reset here to protect against 
     // Chrome X11 FocusOut/FocusIn storms. The state is only reset by the focus_out timeout.
     
-    g_printerr("FOCUS IN ID: client_id='%s', detail='%s'\n", client_id ? client_id : "NULL", detail ? detail : "NULL");
+    if (debug_enabled()) {
+        g_printerr("FOCUS IN ID: client_id='%s', detail='%s'\n",
+                   client_id ? client_id : "NULL", detail ? detail : "NULL");
+    }
 
     if (!client_id || client_id[0] == '\0') {
         engine->app_wants_preedit = false;
@@ -286,16 +361,18 @@ static void ibus_unikey_engine_focus_in_id (IBusEngine *engine_base, const gchar
         active_x11_class = get_active_window_class_x11();
     }
 
-    g_printerr("APP DETECT: comm='%s', exe='%s', client_id='%s', x11_class='%s', is_x11=%d\n",
-               comm.c_str(), exe.c_str(), client_id_str.c_str(), active_x11_class.c_str(), engine->is_x11);
+    if (debug_enabled()) {
+        g_printerr("APP DETECT: comm='%s', exe='%s', client_id='%s', x11_class='%s', is_x11=%d\n",
+                   comm.c_str(), exe.c_str(), client_id_str.c_str(),
+                   active_x11_class.c_str(), engine->is_x11);
 
-    // Ghi debug ra file vì ibus-daemon nuốt stderr
-    FILE *dbg = fopen("/tmp/ibus-unikey-debug.log", "a");
-    if (dbg) {
-        fprintf(dbg, "APP DETECT: comm='%s', exe='%s', client_id='%s', x11_class='%s', is_x11=%d\n",
-                comm.c_str(), exe.c_str(), client_id_str.c_str(), active_x11_class.c_str(), engine->is_x11);
-        fflush(dbg);
-        fclose(dbg);
+        FILE *dbg = fopen("/tmp/ibus-unikey-debug.log", "a");
+        if (dbg) {
+            fprintf(dbg, "APP DETECT: comm='%s', exe='%s', client_id='%s', x11_class='%s', is_x11=%d\n",
+                    comm.c_str(), exe.c_str(), client_id_str.c_str(),
+                    active_x11_class.c_str(), engine->is_x11);
+            fclose(dbg);
+        }
     }
 
     for (const auto& app : preedit_apps) {
@@ -355,6 +432,7 @@ static void ibus_unikey_engine_class_init (IBusUnikeyEngineClass *klass) {
 
 static void ibus_unikey_engine_init (IBusUnikeyEngine *engine) {
     Bamboo_Init();
+    reload_macros();
     engine->viet_mode = true;
     engine->preedit_string = g_string_new("");
     engine->composed_word = new std::string();
@@ -381,7 +459,11 @@ static void ibus_unikey_engine_destroy (IBusObject *object) {
 
 static gboolean ibus_unikey_engine_process_key_event (IBusEngine *engine_base, guint keyval, guint keycode, guint modifiers) {
     IBusUnikeyEngine *engine = IBUS_UNIKEY_ENGINE (engine_base);
-    g_printerr("KEYVAL: %d, char: %c, use_preedit: %d, has_sur: %d, char_backs: %d\n", keyval, keyval < 128 ? keyval : '?', engine->use_preedit, engine->has_surrounding_text, 0);
+    if (debug_enabled()) {
+        g_printerr("KEYVAL: %d, char: %c, use_preedit: %d, has_sur: %d\n",
+                   keyval, keyval < 128 ? keyval : '?', engine->use_preedit,
+                   engine->has_surrounding_text);
+    }
     
     // Bỏ qua khi nhả phím (key release)
     if (modifiers & IBUS_RELEASE_MASK) {
@@ -420,7 +502,8 @@ static gboolean ibus_unikey_engine_process_key_event (IBusEngine *engine_base, g
     } else {
         // Phím chức năng (Arrow, Esc, F1..., ...): commit preedit nếu có rồi trả phím
         if (engine->use_preedit && engine->preedit_string->len > 0) {
-            IBusText *text = ibus_text_new_from_string(engine->preedit_string->str);
+            const std::string final_word = bamboo_string(true);
+            IBusText *text = ibus_text_new_from_string(final_word.c_str());
             ibus_engine_hide_preedit_text(engine_base);
             g_string_truncate(engine->preedit_string, 0);
             ibus_engine_commit_text(engine_base, text);
@@ -429,13 +512,18 @@ static gboolean ibus_unikey_engine_process_key_event (IBusEngine *engine_base, g
         } else {
             std::string current_word = *(engine->composed_word);
             if (!current_word.empty()) {
-                if (g_macroEnabled && g_macros.find(current_word) != g_macros.end()) {
-                    std::string macro_val = g_macros[current_word];
+                std::string final_word = bamboo_string(true);
+                auto macro = g_macros.find(final_word);
+                if (g_macroEnabled && macro != g_macros.end()) {
+                    final_word = macro->second;
+                }
+                if (final_word != current_word) {
                     int char_backs = g_utf8_strlen(current_word.c_str(), -1);
                     if (char_backs > 0) {
-                        ibus_engine_delete_surrounding_text(engine_base, -char_backs, char_backs);
+                        delete_composition_and_selection(
+                            engine_base, engine, static_cast<guint>(char_backs));
                     }
-                    IBusText *text = ibus_text_new_from_string(macro_val.c_str());
+                    IBusText *text = ibus_text_new_from_string(final_word.c_str());
                     ibus_engine_commit_text(engine_base, text);
                 }
             }
@@ -513,17 +601,22 @@ static gboolean ibus_unikey_engine_process_key_event (IBusEngine *engine_base, g
             }
             Bamboo_RemoveLastChar();
         } else if (!Bamboo_CanProcessKey(c)) {
-            std::string current_word = *(engine->composed_word);
+            const std::string current_word = *(engine->composed_word);
+            std::string final_word = bamboo_string(true);
             *(engine->composed_word) = "";
             Bamboo_Reset();
 
-            if (g_macroEnabled && g_macros.find(current_word) != g_macros.end()) {
-                std::string macro_val = g_macros[current_word];
+            auto macro = g_macros.find(final_word);
+            if (g_macroEnabled && macro != g_macros.end()) {
+                final_word = macro->second;
+            }
+            if (final_word != current_word) {
                 int char_backs = g_utf8_strlen(current_word.c_str(), -1);
                 if (char_backs > 0) {
-                    ibus_engine_delete_surrounding_text(engine_base, -char_backs, char_backs);
+                    delete_composition_and_selection(
+                        engine_base, engine, static_cast<guint>(char_backs));
                 }
-                IBusText *text = ibus_text_new_from_string(macro_val.c_str());
+                IBusText *text = ibus_text_new_from_string(final_word.c_str());
                 ibus_engine_commit_text(engine_base, text);
             }
             return FALSE;
@@ -553,8 +646,8 @@ static gboolean ibus_unikey_engine_process_key_event (IBusEngine *engine_base, g
         }
         
         if (char_backs > 0) {
-            // Trả về đúng nguyên bản github: Luôn xoá bằng delete_surrounding_text
-            ibus_engine_delete_surrounding_text(engine_base, -char_backs, char_backs);
+            delete_composition_and_selection(
+                engine_base, engine, static_cast<guint>(char_backs));
         }
 
         // Commit phần suffix mới
@@ -597,11 +690,12 @@ static void ibus_unikey_engine_focus_in (IBusEngine *engine_base) {
         std::string active_class = get_active_window_class_x11();
         engine->app_wants_preedit = false;
 
-        FILE *dbg = fopen("/tmp/ibus-unikey-debug.log", "a");
-        if (dbg) {
-            fprintf(dbg, "FOCUS_IN X11: active_class='%s'\n", active_class.c_str());
-            fflush(dbg);
-            fclose(dbg);
+        if (debug_enabled()) {
+            FILE *dbg = fopen("/tmp/ibus-unikey-debug.log", "a");
+            if (dbg) {
+                fprintf(dbg, "FOCUS_IN X11: active_class='%s'\n", active_class.c_str());
+                fclose(dbg);
+            }
         }
 
         for (const auto& app : preedit_apps) {
@@ -652,9 +746,8 @@ static void ibus_unikey_engine_property_activate (IBusEngine *engine, const gcha
 
 static gboolean focus_out_timeout_cb(gpointer user_data) {
     IBusUnikeyEngine *engine = IBUS_UNIKEY_ENGINE(user_data);
-    engine->composed_word->clear();
-    Bamboo_Reset();
     g_focus_out_timer_id = 0;
+    ibus_unikey_engine_reset(IBUS_ENGINE(engine));
     return G_SOURCE_REMOVE;
 }
 
@@ -665,7 +758,12 @@ static void ibus_unikey_engine_focus_out(IBusEngine *engine_base) {
         g_source_remove(g_focus_out_timer_id);
     }
     // Trì hoãn việc xoá state 50ms để chống lại lỗi Focus Storm của Chrome
-    g_focus_out_timer_id = g_timeout_add(50, focus_out_timeout_cb, engine);
+    g_focus_out_timer_id = g_timeout_add_full(
+        G_PRIORITY_DEFAULT,
+        50,
+        focus_out_timeout_cb,
+        g_object_ref(engine),
+        g_object_unref);
 }
 
 static void ibus_unikey_engine_reset (IBusEngine *engine_base) {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLIENT_DIR="$REPO_DIR/wayland-client"
+
+echo "=========================================================="
+echo "    Vietnamese IME (Unikey-Wayland) Installation Script   "
+echo "=========================================================="
+
+# 1. Check prerequisites
+echo "🔍 [1/4] Kiểm tra môi trường và công cụ biên dịch..."
+command -v go >/dev/null 2>&1 || { echo "❌ Lỗi: Chưa cài đặt 'go' (Golang)."; exit 1; }
+command -v g++ >/dev/null 2>&1 || { echo "❌ Lỗi: Chưa cài đặt 'g++'."; exit 1; }
+command -v gcc >/dev/null 2>&1 || { echo "❌ Lỗi: Chưa cài đặt 'gcc'."; exit 1; }
+command -v pkg-config >/dev/null 2>&1 || { echo "❌ Lỗi: Chưa cài đặt 'pkg-config'."; exit 1; }
+command -v wayland-scanner >/dev/null 2>&1 || { echo "❌ Lỗi: Chưa cài đặt 'wayland-scanner'."; exit 1; }
+
+# Tìm kiếm Qt6 moc binary
+MOC_BIN=""
+for path in \
+    "$(which moc-qt6 2>/dev/null)" \
+    "$(which moc 2>/dev/null)" \
+    "/usr/lib64/qt6/libexec/moc" \
+    "/usr/lib/qt6/libexec/moc" \
+    "/usr/lib64/qt6/bin/moc" \
+    "/usr/lib/qt6/bin/moc" \
+    "/usr/local/qt6/bin/moc"
+do
+    if [ -n "$path" ] && [ -x "$path" ]; then
+        MOC_BIN="$path"
+        break
+    fi
+done
+
+if [ -z "$MOC_BIN" ]; then
+    echo "❌ Lỗi: Không tìm thấy Qt6 moc. Vui lòng cài đặt gói phát triển Qt6 (qt6-qtbase-devel / qt6-base-dev)."
+    exit 1
+fi
+echo "   -> Tìm thấy Qt6 moc tại: $MOC_BIN"
+
+cd "$CLIENT_DIR"
+
+# 2. Build Go Bamboo Core C-Archive
+echo "🔨 [2/4] Đang biên dịch lõi Go Bamboo Core (libbamboo.a)..."
+cd src
+CGO_ENABLED=1 go build -buildmode=c-archive -o libbamboo.a bamboo_wrapper.go
+cd ..
+
+# 3. Generate Wayland Protocols & Qt MOC
+echo "⚙️ [3/4] Đang sinh mã giao thức Wayland và biên dịch C++..."
+wayland-scanner client-header protocols/input-method-unstable-v1.xml include/input-method-unstable-v1-client-protocol.h
+wayland-scanner private-code protocols/input-method-unstable-v1.xml src/input-method-unstable-v1-protocol.c
+
+"$MOC_BIN" src/mainwindow.h -o src/moc_mainwindow.cpp
+"$MOC_BIN" src/macrodialog.h -o src/moc_macrodialog.cpp
+"$MOC_BIN" src/windowtracker.h -o src/moc_windowtracker.cpp
+"$MOC_BIN" src/trayicon.h -o src/moc_trayicon.cpp
+
+mkdir -p "$HOME/.local/bin"
+gcc -c src/input-method-unstable-v1-protocol.c -Iinclude -o src/input-method-unstable-v1-protocol.o
+g++ -std=c++17 -O2 -D_LINUX -Isrc -Iinclude $(pkg-config --cflags Qt6Widgets Qt6Gui Qt6Core Qt6DBus wayland-client) \
+  src/main.cpp src/mainwindow.cpp src/macrodialog.cpp src/windowtracker.cpp src/trayicon.cpp \
+  src/moc_mainwindow.cpp src/moc_macrodialog.cpp src/moc_trayicon.cpp src/moc_windowtracker.cpp \
+  src/input-method-unstable-v1-protocol.o src/libbamboo.a \
+  $(pkg-config --libs Qt6Widgets Qt6Gui Qt6Core Qt6DBus wayland-client) -lpthread -lresolv \
+  -o "$HOME/.local/bin/unikey-wayland"
+
+# 4. Install Desktop Entry, Icon & Configure KWin
+echo "✨ [4/4] Cài đặt Desktop Entry, Icon và kích hoạt KWin Virtual Keyboard..."
+mkdir -p "$HOME/.local/share/applications" "$HOME/.local/share/icons/hicolor/scalable/apps"
+cp "$REPO_DIR/io.github.ubuntu2310fake.UnikeyWayland.desktop" "$HOME/.local/share/applications/"
+cp "$REPO_DIR/io.github.ubuntu2310fake.UnikeyWayland.svg" "$HOME/.local/share/icons/hicolor/scalable/apps/"
+update-desktop-database "$HOME/.local/share/applications/" 2>/dev/null || true
+
+# Tạo default preedit_apps.txt nếu chưa có
+mkdir -p "$HOME/UnikeyWayland"
+if [ ! -f "$HOME/UnikeyWayland/preedit_apps.txt" ]; then
+    cat << 'APPS' > "$HOME/UnikeyWayland/preedit_apps.txt"
+kitty
+alacritty
+konsole
+gnome-terminal
+xfce4-terminal
+lxterminal
+android-studio
+java
+APPS
+fi
+
+# Cấu hình KWin Wayland
+if command -v kwriteconfig6 >/dev/null 2>&1; then
+    kwriteconfig6 --file kwinrc --group Wayland --key InputMethod "$HOME/.local/share/applications/io.github.ubuntu2310fake.UnikeyWayland.desktop"
+    kwriteconfig6 --file kwinrc --group Wayland --key VirtualKeyboard "$HOME/.local/share/applications/io.github.ubuntu2310fake.UnikeyWayland.desktop"
+    kwriteconfig6 --file kwinrc --group Wayland --key VirtualKeyboardEnabled true
+fi
+
+# Kích hoạt / Tải lại bộ gõ
+pkill -9 unikey-wayland 2>/dev/null || true
+dbus-send --session --dest=org.kde.KWin --type=method_call /KWin org.kde.KWin.reconfigure 2>/dev/null || true
+dbus-send --session --dest=org.kde.KWin --type=method_call /VirtualKeyboard org.freedesktop.DBus.Properties.Set string:"org.kde.kwin.VirtualKeyboard" string:"enabled" variant:boolean:true 2>/dev/null || true
+
+echo "=========================================================="
+echo "🎉 Cài đặt hoàn tất! Unikey-Wayland đã được kích hoạt."
+echo "⌨️ Phím tắt mặc định: Ctrl + Shift để chuyển đổi V/E."
+echo "=========================================================="

--- a/wayland-client/CMakeLists.txt
+++ b/wayland-client/CMakeLists.txt
@@ -4,16 +4,13 @@ project(unikey-wayland LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find Qt6 components
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
-
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
+pkg_check_modules(WAYLAND_CLIENT REQUIRED IMPORTED_TARGET wayland-client)
 find_package(Qt6 COMPONENTS Core Gui Widgets DBus REQUIRED)
 
-# Wayland protocol generation
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+
 find_program(WAYLAND_SCANNER_BIN wayland-scanner REQUIRED)
 set(PROTOCOL_XML ${CMAKE_CURRENT_SOURCE_DIR}/protocols/input-method-unstable-v1.xml)
 set(PROTOCOL_C ${CMAKE_CURRENT_BINARY_DIR}/input-method-unstable-v1-protocol.c)
@@ -24,60 +21,86 @@ add_custom_command(
     COMMAND ${WAYLAND_SCANNER_BIN} private-code ${PROTOCOL_XML} ${PROTOCOL_C}
     DEPENDS ${PROTOCOL_XML}
 )
-
 add_custom_command(
     OUTPUT ${PROTOCOL_H}
     COMMAND ${WAYLAND_SCANNER_BIN} client-header ${PROTOCOL_XML} ${PROTOCOL_H}
     DEPENDS ${PROTOCOL_XML}
 )
 
-# Source files
+find_program(GO_BIN go REQUIRED)
+set(BAMBOO_LIB ${CMAKE_CURRENT_SOURCE_DIR}/src/libbamboo.a)
+file(GLOB_RECURSE BAMBOO_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.go
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor/*.go
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/vendor/modules.txt
+)
+add_custom_command(
+    OUTPUT ${BAMBOO_LIB} ${CMAKE_CURRENT_SOURCE_DIR}/src/libbamboo.h
+    COMMAND ${GO_BIN} build -mod=vendor -buildmode=c-archive -o ${BAMBOO_LIB} bamboo_wrapper.go
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src
+    DEPENDS ${BAMBOO_SOURCES}
+)
+add_custom_target(bamboo_target DEPENDS ${BAMBOO_LIB})
+
 set(UK_SOURCES
     src/trayicon.cpp
     src/mainwindow.cpp
     src/macrodialog.cpp
     src/windowtracker.cpp
     src/main.cpp
+    src/text_transaction.h
 )
-
-find_program(GO_BIN go REQUIRED)
-set(BAMBOO_LIB ${CMAKE_CURRENT_SOURCE_DIR}/src/libbamboo.a)
-add_custom_command(
-    OUTPUT ${BAMBOO_LIB} ${CMAKE_CURRENT_SOURCE_DIR}/src/libbamboo.h
-    COMMAND ${GO_BIN} build -mod=vendor -buildmode=c-archive -o ${BAMBOO_LIB} bamboo_wrapper.go
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/bamboo_wrapper.go
-)
-
-add_custom_target(bamboo_target DEPENDS ${BAMBOO_LIB})
-
-add_executable(unikey-wayland 
-    ${UK_SOURCES} 
+add_executable(unikey-wayland
+    ${UK_SOURCES}
     ${PROTOCOL_C}
     ${PROTOCOL_H}
-    resources/resources.qrc
 )
-
 add_dependencies(unikey-wayland bamboo_target)
-
-target_include_directories(unikey-wayland PRIVATE 
-    src 
-    ${CMAKE_CURRENT_BINARY_DIR} 
+target_include_directories(unikey-wayland PRIVATE
+    src
+    ${CMAKE_CURRENT_BINARY_DIR}
     include
 )
-
-# Add preprocessor definition so it avoids MFC/Windows headers if possible, 
-# though we supply our own windows.h
-target_compile_definitions(unikey-wayland PRIVATE _LINUX)
-
+target_compile_definitions(unikey-wayland PRIVATE _LINUX_)
 target_link_libraries(unikey-wayland PRIVATE
-    ${WAYLAND_CLIENT_LIBRARIES}
+    PkgConfig::WAYLAND_CLIENT
     Qt6::Core
     Qt6::Gui
     Qt6::Widgets
     Qt6::DBus
     ${BAMBOO_LIB}
-    pthread
 )
 
+# IBus backend for GNOME Wayland and X11 sessions.
+pkg_check_modules(IBUS IMPORTED_TARGET ibus-1.0)
+if (IBUS_FOUND)
+    add_executable(ibus-engine-unikey-wayland ../ibus-engine/main.cpp)
+    add_dependencies(ibus-engine-unikey-wayland bamboo_target)
+    target_include_directories(ibus-engine-unikey-wayland PRIVATE src)
+    target_compile_definitions(ibus-engine-unikey-wayland PRIVATE _LINUX_)
+    target_link_libraries(ibus-engine-unikey-wayland PRIVATE
+        PkgConfig::IBUS
+        ${BAMBOO_LIB}
+    )
+
+    install(TARGETS ibus-engine-unikey-wayland DESTINATION libexec)
+    install(FILES ../ibus-engine/unikey-wayland.xml DESTINATION share/ibus/component)
+    install(FILES ../ibus-engine/ibus-setup-unikey-wayland.desktop DESTINATION share/applications)
+endif()
+
 install(TARGETS unikey-wayland DESTINATION bin)
+install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.desktop DESTINATION share/applications)
+install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.metainfo.xml DESTINATION share/metainfo)
+install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.svg DESTINATION share/icons/hicolor/scalable/apps)
+
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(text-transaction-test tests/text_transaction_test.cpp)
+    target_include_directories(text-transaction-test PRIVATE src)
+    add_test(NAME text-transaction-test COMMAND text-transaction-test)
+    add_test(
+        NAME bamboo-wrapper-test
+        COMMAND ${GO_BIN} test -mod=vendor bamboo_wrapper.go bamboo_wrapper_test.go
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+endif()

--- a/wayland-client/CMakeLists.txt
+++ b/wayland-client/CMakeLists.txt
@@ -1,113 +1,83 @@
-cmake_minimum_required(VERSION 3.10)
-project(unikey-wayland C CXX)
+cmake_minimum_required(VERSION 3.16)
+project(unikey-wayland LANGUAGES C CXX)
 
-set(CMAKE_CXX_STANDARD 11)
-add_definitions(-DUKW_VERSION="2.0.10")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Dependencies
+# Find Qt6 components
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
-pkg_check_modules(WAYLAND_SCANNER REQUIRED wayland-scanner)
 
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-
 find_package(Qt6 COMPONENTS Core Gui Widgets DBus REQUIRED)
 
 # Wayland protocol generation
-pkg_get_variable(WAYLAND_SCANNER_BIN wayland-scanner wayland_scanner)
+find_program(WAYLAND_SCANNER_BIN wayland-scanner REQUIRED)
 set(PROTOCOL_XML ${CMAKE_CURRENT_SOURCE_DIR}/protocols/input-method-unstable-v1.xml)
 set(PROTOCOL_C ${CMAKE_CURRENT_BINARY_DIR}/input-method-unstable-v1-protocol.c)
 set(PROTOCOL_H ${CMAKE_CURRENT_BINARY_DIR}/input-method-unstable-v1-client-protocol.h)
 
 add_custom_command(
-    OUTPUT ${PROTOCOL_C} ${PROTOCOL_H}
+    OUTPUT ${PROTOCOL_C}
     COMMAND ${WAYLAND_SCANNER_BIN} private-code ${PROTOCOL_XML} ${PROTOCOL_C}
+    DEPENDS ${PROTOCOL_XML}
+)
+
+add_custom_command(
+    OUTPUT ${PROTOCOL_H}
     COMMAND ${WAYLAND_SCANNER_BIN} client-header ${PROTOCOL_XML} ${PROTOCOL_H}
     DEPENDS ${PROTOCOL_XML}
 )
 
-# UniKey sources
+# Source files
 set(UK_SOURCES
-    src/mainwindow.cpp
     src/trayicon.cpp
+    src/mainwindow.cpp
     src/macrodialog.cpp
     src/windowtracker.cpp
     src/main.cpp
 )
 
+find_program(GO_BIN go REQUIRED)
 set(BAMBOO_LIB ${CMAKE_CURRENT_SOURCE_DIR}/src/libbamboo.a)
 add_custom_command(
     OUTPUT ${BAMBOO_LIB} ${CMAKE_CURRENT_SOURCE_DIR}/src/libbamboo.h
-    COMMAND go build -mod=vendor -buildmode=c-archive -o ${BAMBOO_LIB} bamboo_wrapper.go
+    COMMAND ${GO_BIN} build -mod=vendor -buildmode=c-archive -o ${BAMBOO_LIB} bamboo_wrapper.go
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/bamboo_wrapper.go
 )
+
 add_custom_target(bamboo_target DEPENDS ${BAMBOO_LIB})
 
-add_executable(unikey-wayland ${PROTOCOL_C} ${UK_SOURCES})
+add_executable(unikey-wayland 
+    ${UK_SOURCES} 
+    ${PROTOCOL_C}
+    ${PROTOCOL_H}
+    resources/resources.qrc
+)
+
+add_dependencies(unikey-wayland bamboo_target)
+
 target_include_directories(unikey-wayland PRIVATE 
+    src 
     ${CMAKE_CURRENT_BINARY_DIR} 
     include
 )
 
 # Add preprocessor definition so it avoids MFC/Windows headers if possible, 
 # though we supply our own windows.h
-target_compile_definitions(unikey-wayland PRIVATE 
-    -D_LINUX_
-)
-target_compile_options(unikey-wayland PRIVATE
-    -Wno-narrowing
-    -include "${CMAKE_CURRENT_SOURCE_DIR}/include/windows_macros.h"
-)
-set_target_properties(unikey-wayland PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(unikey-wayland PRIVATE _LINUX)
 
-target_link_libraries(unikey-wayland PRIVATE 
+target_link_libraries(unikey-wayland PRIVATE
     ${WAYLAND_CLIENT_LIBRARIES}
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::DBus
     ${BAMBOO_LIB}
-    Qt6::Core Qt6::Gui Qt6::Widgets Qt6::DBus
-    rt
+    pthread
 )
-add_dependencies(unikey-wayland bamboo_target)
-
-# IBus Engine
-pkg_check_modules(IBUS ibus-1.0)
-if (IBUS_FOUND)
-    set(IBUS_SOURCES
-        ../ibus-engine/main.cpp
-    )
-
-    add_executable(ibus-engine-unikey-wayland ${IBUS_SOURCES})
-    target_include_directories(ibus-engine-unikey-wayland PRIVATE 
-        ${IBUS_INCLUDE_DIRS}
-        include
-        src
-    )
-    
-    target_compile_definitions(ibus-engine-unikey-wayland PRIVATE 
-        -D_LINUX_
-    )
-    target_compile_options(ibus-engine-unikey-wayland PRIVATE
-        -Wno-narrowing
-        -include "${CMAKE_CURRENT_SOURCE_DIR}/include/windows_macros.h"
-        ${IBUS_CFLAGS_OTHER}
-    )
-
-    target_link_libraries(ibus-engine-unikey-wayland PRIVATE 
-        ${IBUS_LIBRARIES}
-        ${BAMBOO_LIB}
-        rt
-    )
-    add_dependencies(ibus-engine-unikey-wayland bamboo_target)
-
-    # Install rules
-    install(TARGETS ibus-engine-unikey-wayland DESTINATION libexec)
-    install(FILES ../ibus-engine/unikey-wayland.xml DESTINATION share/ibus/component)
-    install(FILES ../ibus-engine/ibus-setup-unikey-wayland.desktop DESTINATION share/applications)
-endif()
 
 install(TARGETS unikey-wayland DESTINATION bin)
-install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.desktop DESTINATION share/applications)
-install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.metainfo.xml DESTINATION share/metainfo)
-install(FILES ../io.github.ubuntu2310fake.UnikeyWayland.svg DESTINATION share/icons/hicolor/scalable/apps)
-

--- a/wayland-client/src/bamboo_wrapper.go
+++ b/wayland-client/src/bamboo_wrapper.go
@@ -13,6 +13,8 @@ import (
 var preeditor bamboo.IEngine
 var currentMethod string = "Telex"
 var currentFlags uint = bamboo.EfreeToneMarking
+var spellCheckEnabled bool
+var autoRestoreEnabled bool
 var rawKeys []rune
 
 func initEngine(methodName string) {
@@ -20,7 +22,7 @@ func initEngine(methodName string) {
 	defs := bamboo.GetInputMethodDefinitions()
 	im := bamboo.ParseInputMethod(defs, currentMethod)
 	preeditor = bamboo.NewEngine(im, currentFlags)
-	rawKeys = make([]rune, 0)
+	rawKeys = rawKeys[:0]
 }
 
 //export Bamboo_Init
@@ -61,9 +63,8 @@ func Bamboo_SetOptions(freeMarking C.bool, modernStyle C.bool, spellCheck C.bool
 	if !bool(modernStyle) {
 		flags |= bamboo.EstdToneStyle
 	}
-	if bool(spellCheck) {
-		flags |= bamboo.EautoCorrectEnabled
-	}
+	spellCheckEnabled = bool(spellCheck)
+	autoRestoreEnabled = bool(autoRestore)
 	currentFlags = flags
 	if preeditor != nil {
 		preeditor.SetFlag(currentFlags)
@@ -80,23 +81,50 @@ func Bamboo_CanProcessKey(key C.uint32_t) C.bool {
 
 //export Bamboo_ProcessKey
 func Bamboo_ProcessKey(key C.uint32_t) {
-	if preeditor != nil {
-        rawKeys = append(rawKeys, rune(key))
-		preeditor.ProcessKey(rune(key), bamboo.VietnameseMode)
-	}
+	processKey(rune(key))
 }
 
 //export Bamboo_RemoveLastChar
 func Bamboo_RemoveLastChar() {
+	removeLastKey()
+}
+
+func processKey(key rune) {
 	if preeditor != nil {
-        if len(rawKeys) > 0 {
-            rawKeys = rawKeys[:len(rawKeys)-1]
-            preeditor.Reset()
-            for _, k := range rawKeys {
-                preeditor.ProcessKey(k, bamboo.VietnameseMode)
-            }
-        }
+		rawKeys = append(rawKeys, key)
+		preeditor.ProcessKey(key, bamboo.VietnameseMode)
 	}
+}
+
+// Replay raw keys because a transformation may consume more than one key.
+func removeLastKey() {
+	if preeditor == nil || len(rawKeys) == 0 {
+		return
+	}
+	rawKeys = rawKeys[:len(rawKeys)-1]
+	preeditor.Reset()
+	for _, key := range rawKeys {
+		preeditor.ProcessKey(key, bamboo.VietnameseMode)
+	}
+}
+
+// Use the stricter validation only when the word is committed.
+func processedString(final bool) string {
+	if preeditor == nil {
+		return ""
+	}
+
+	vietnamese := preeditor.GetProcessedString(bamboo.VietnameseMode)
+	if !bamboo.HasAnyVietnameseRune(vietnamese) {
+		return vietnamese
+	}
+
+	invalidPartial := spellCheckEnabled && !preeditor.IsValid(false)
+	invalidFinal := final && autoRestoreEnabled && !preeditor.IsValid(true)
+	if invalidPartial || invalidFinal {
+		return preeditor.GetProcessedString(bamboo.EnglishMode)
+	}
+	return vietnamese
 }
 
 //export Bamboo_GetPreeditString
@@ -104,21 +132,18 @@ func Bamboo_GetPreeditString() *C.char {
 	if preeditor == nil {
 		return C.CString("")
 	}
-	vnSeq := preeditor.GetProcessedString(bamboo.VietnameseMode)
-    
-	return C.CString(vnSeq)
+	return C.CString(processedString(false))
 }
 
 //export Bamboo_GetCommitString
 func Bamboo_GetCommitString() *C.char {
-	// Commit string is the same as Preedit string right before reset
-	return Bamboo_GetPreeditString()
+	return C.CString(processedString(true))
 }
 
 //export Bamboo_Reset
 func Bamboo_Reset() {
 	if preeditor != nil {
-        rawKeys = make([]rune, 0)
+		rawKeys = rawKeys[:0]
 		preeditor.Reset()
 	}
 }

--- a/wayland-client/src/bamboo_wrapper.go
+++ b/wayland-client/src/bamboo_wrapper.go
@@ -11,15 +11,38 @@ import (
 )
 
 var preeditor bamboo.IEngine
-
+var currentMethod string = "Telex"
 var rawKeys []rune
+
+func initEngine(methodName string) {
+	currentMethod = methodName
+	defs := bamboo.GetInputMethodDefinitions()
+	im := bamboo.ParseInputMethod(defs, currentMethod)
+	preeditor = bamboo.NewEngine(im, uint(bamboo.VietnameseMode))
+	rawKeys = make([]rune, 0)
+}
 
 //export Bamboo_Init
 func Bamboo_Init() {
-    defs := bamboo.GetInputMethodDefinitions()
-	im := bamboo.ParseInputMethod(defs, "Telex")
-	preeditor = bamboo.NewEngine(im, uint(bamboo.VietnameseMode))
-    rawKeys = make([]rune, 0)
+	initEngine("Telex")
+}
+
+//export Bamboo_SetInputMethod
+func Bamboo_SetInputMethod(method C.int) {
+	methodName := "Telex"
+	switch int(method) {
+	case 1:
+		methodName = "Telex"
+	case 2:
+		methodName = "VNI"
+	case 3:
+		methodName = "VIQR"
+	case 4:
+		methodName = "Telex 2"
+	default:
+		methodName = "Telex"
+	}
+	initEngine(methodName)
 }
 
 //export Bamboo_CanProcessKey

--- a/wayland-client/src/bamboo_wrapper.go
+++ b/wayland-client/src/bamboo_wrapper.go
@@ -12,13 +12,14 @@ import (
 
 var preeditor bamboo.IEngine
 var currentMethod string = "Telex"
+var currentFlags uint = bamboo.EfreeToneMarking
 var rawKeys []rune
 
 func initEngine(methodName string) {
 	currentMethod = methodName
 	defs := bamboo.GetInputMethodDefinitions()
 	im := bamboo.ParseInputMethod(defs, currentMethod)
-	preeditor = bamboo.NewEngine(im, uint(bamboo.VietnameseMode))
+	preeditor = bamboo.NewEngine(im, currentFlags)
 	rawKeys = make([]rune, 0)
 }
 
@@ -43,6 +44,30 @@ func Bamboo_SetInputMethod(method C.int) {
 		methodName = "Telex"
 	}
 	initEngine(methodName)
+}
+
+//export Bamboo_SetOptions
+func Bamboo_SetOptions(freeMarking C.bool, modernStyle C.bool, spellCheck C.bool, autoRestore C.bool) {
+	var flags uint = 0
+	if bool(freeMarking) {
+		flags |= bamboo.EfreeToneMarking
+	}
+	// Bamboo Core semantics:
+	// EstdToneStyle (true) puts tone on first vowel -> òa, úy (truyền thống)
+	// EstdToneStyle (false) puts tone on second vowel -> oà, uý (kiểu mới)
+	// Checkbox "Đặt dấu oà, uý (thay vì òa, úy)":
+	// Unticked (false) -> user wants òa, úy -> set EstdToneStyle
+	// Ticked (true) -> user wants oà, uý -> clear EstdToneStyle
+	if !bool(modernStyle) {
+		flags |= bamboo.EstdToneStyle
+	}
+	if bool(spellCheck) {
+		flags |= bamboo.EautoCorrectEnabled
+	}
+	currentFlags = flags
+	if preeditor != nil {
+		preeditor.SetFlag(currentFlags)
+	}
 }
 
 //export Bamboo_CanProcessKey

--- a/wayland-client/src/bamboo_wrapper_test.go
+++ b/wayland-client/src/bamboo_wrapper_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/BambooEngine/bamboo-core"
+)
+
+func typeKeys(keys string) {
+	for _, key := range keys {
+		processKey(key)
+	}
+}
+
+func resetTestEngine(method string, spellCheck, autoRestore bool) {
+	currentFlags = bamboo.EfreeToneMarking
+	spellCheckEnabled = spellCheck
+	autoRestoreEnabled = autoRestore
+	initEngine(method)
+}
+
+func TestTelexComposition(t *testing.T) {
+	resetTestEngine("Telex", true, true)
+	typeKeys("theer")
+	if got := processedString(true); got != "thể" {
+		t.Fatalf("theer: got %q, want %q", got, "thể")
+	}
+}
+
+func TestInputMethodsSelectedBySettings(t *testing.T) {
+	tests := []struct {
+		method string
+		keys   string
+	}{
+		{method: "VNI", keys: "the63"},
+		{method: "VIQR", keys: "the^?"},
+		{method: "Telex 2", keys: "theer"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method, func(t *testing.T) {
+			resetTestEngine(tc.method, true, true)
+			typeKeys(tc.keys)
+			if got := processedString(true); got != "thể" {
+				t.Fatalf("%s: got %q, want %q", tc.keys, got, "thể")
+			}
+		})
+	}
+}
+
+func TestInvalidVietnameseSequenceRestoresRawKeys(t *testing.T) {
+	resetTestEngine("Telex", true, true)
+	typeKeys("afc") // àc is invalid: c only accepts acute or dot tones.
+	if got := processedString(true); got != "afc" {
+		t.Fatalf("got %q, want raw keys %q", got, "afc")
+	}
+}
+
+func TestAutoRestoreCanBeDisabled(t *testing.T) {
+	resetTestEngine("Telex", false, false)
+	typeKeys("afc")
+	if got := processedString(true); got != "àc" {
+		t.Fatalf("got %q, want un-restored composition %q", got, "àc")
+	}
+}
+
+func TestBackspaceReplaysBambooStateCorrectly(t *testing.T) {
+	resetTestEngine("Telex", true, true)
+	typeKeys("theer")
+	removeLastKey()
+	if got := processedString(false); got != "thê" {
+		t.Fatalf("got %q, want %q", got, "thê")
+	}
+}

--- a/wayland-client/src/libbamboo.h
+++ b/wayland-client/src/libbamboo.h
@@ -12,6 +12,8 @@
 
 #ifndef GO_CGO_GOSTRING_TYPEDEF
 typedef struct { const char *p; ptrdiff_t n; } _GoString_;
+extern size_t _GoStringLen(_GoString_ s);
+extern const char *_GoStringPtr(_GoString_ s);
 #endif
 
 #endif
@@ -51,9 +53,15 @@ typedef size_t GoUintptr;
 typedef float GoFloat32;
 typedef double GoFloat64;
 #ifdef _MSC_VER
+#if !defined(__cplusplus) || _MSVC_LANG <= 201402L
 #include <complex.h>
 typedef _Fcomplex GoComplex64;
 typedef _Dcomplex GoComplex128;
+#else
+#include <complex>
+typedef std::complex<float> GoComplex64;
+typedef std::complex<double> GoComplex128;
+#endif
 #else
 typedef float _Complex GoComplex64;
 typedef double _Complex GoComplex128;
@@ -81,14 +89,15 @@ typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;
 extern "C" {
 #endif
 
-extern void Bamboo_Init();
+extern void Bamboo_Init(void);
 extern void Bamboo_SetInputMethod(int method);
+extern void Bamboo_SetOptions(_Bool freeMarking, _Bool modernStyle, _Bool spellCheck, _Bool autoRestore);
 extern _Bool Bamboo_CanProcessKey(uint32_t key);
 extern void Bamboo_ProcessKey(uint32_t key);
-extern void Bamboo_RemoveLastChar();
-extern char* Bamboo_GetPreeditString();
-extern char* Bamboo_GetCommitString();
-extern void Bamboo_Reset();
+extern void Bamboo_RemoveLastChar(void);
+extern char* Bamboo_GetPreeditString(void);
+extern char* Bamboo_GetCommitString(void);
+extern void Bamboo_Reset(void);
 
 #ifdef __cplusplus
 }

--- a/wayland-client/src/libbamboo.h
+++ b/wayland-client/src/libbamboo.h
@@ -12,8 +12,6 @@
 
 #ifndef GO_CGO_GOSTRING_TYPEDEF
 typedef struct { const char *p; ptrdiff_t n; } _GoString_;
-extern size_t _GoStringLen(_GoString_ s);
-extern const char *_GoStringPtr(_GoString_ s);
 #endif
 
 #endif
@@ -53,15 +51,9 @@ typedef size_t GoUintptr;
 typedef float GoFloat32;
 typedef double GoFloat64;
 #ifdef _MSC_VER
-#if !defined(__cplusplus) || _MSVC_LANG <= 201402L
 #include <complex.h>
 typedef _Fcomplex GoComplex64;
 typedef _Dcomplex GoComplex128;
-#else
-#include <complex>
-typedef std::complex<float> GoComplex64;
-typedef std::complex<double> GoComplex128;
-#endif
 #else
 typedef float _Complex GoComplex64;
 typedef double _Complex GoComplex128;
@@ -89,13 +81,14 @@ typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;
 extern "C" {
 #endif
 
-extern void Bamboo_Init(void);
+extern void Bamboo_Init();
+extern void Bamboo_SetInputMethod(int method);
 extern _Bool Bamboo_CanProcessKey(uint32_t key);
 extern void Bamboo_ProcessKey(uint32_t key);
-extern void Bamboo_RemoveLastChar(void);
-extern char* Bamboo_GetPreeditString(void);
-extern char* Bamboo_GetCommitString(void);
-extern void Bamboo_Reset(void);
+extern void Bamboo_RemoveLastChar();
+extern char* Bamboo_GetPreeditString();
+extern char* Bamboo_GetCommitString();
+extern void Bamboo_Reset();
 
 #ifdef __cplusplus
 }

--- a/wayland-client/src/main.cpp
+++ b/wayland-client/src/main.cpp
@@ -176,12 +176,22 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
         return;
     }
 
+    static bool g_switched = false;
+
     // Track modifier key states
     if (state_key == 1) { // Pressed
         if (key == 29 || key == 97) { // Left/Right Ctrl
             g_ctrl_pressed = true;
+            if (!g_shift_pressed && !g_alt_pressed) {
+                g_other_pressed = false;
+                g_switched = false;
+            }
         } else if (key == 42 || key == 54) { // Left/Right Shift
             g_shift_pressed = true;
+            if (!g_ctrl_pressed && !g_alt_pressed) {
+                g_other_pressed = false;
+                g_switched = false;
+            }
         } else if (key == 56 || key == 100) { // Left/Right Alt
             g_alt_pressed = true;
         } else {
@@ -190,25 +200,33 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
     } else if (state_key == 0) { // Released
         int switchKeyConfig = g_mainWindow ? g_mainWindow->getSwitchKey() : 0;
         if (key == 29 || key == 97) {
-            if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed) {
+            if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed && !g_switched) {
                 if (g_mainWindow) {
                     g_mainWindow->setVietMode(!state->viet_mode);
                 } else {
                     state->viet_mode = !state->viet_mode;
                 }
+                g_switched = true;
             }
             g_ctrl_pressed = false;
-            g_other_pressed = false;
+            if (!g_shift_pressed) {
+                g_other_pressed = false;
+                g_switched = false;
+            }
         } else if (key == 42 || key == 54) {
-            if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed) {
+            if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed && !g_switched) {
                 if (g_mainWindow) {
                     g_mainWindow->setVietMode(!state->viet_mode);
                 } else {
                     state->viet_mode = !state->viet_mode;
                 }
+                g_switched = true;
             }
             g_shift_pressed = false;
-            g_other_pressed = false;
+            if (!g_ctrl_pressed) {
+                g_other_pressed = false;
+                g_switched = false;
+            }
         } else if (key == 56 || key == 100) {
             g_alt_pressed = false;
             g_other_pressed = false;
@@ -448,6 +466,13 @@ static void keyboard_modifiers(void* data, struct wl_keyboard* keyboard, uint32_
     WaylandState* state = static_cast<WaylandState*>(data);
     g_modifiers = mods_depressed | mods_latched | mods_locked;
     
+    if (mods_depressed == 0) {
+        g_ctrl_pressed = false;
+        g_shift_pressed = false;
+        g_alt_pressed = false;
+        g_other_pressed = false;
+    }
+
     if (state->context) {
         zwp_input_method_context_v1_modifiers(state->context, serial, mods_depressed, mods_latched, mods_locked, group);
     }
@@ -513,6 +538,11 @@ static void input_method_activate(void* data, struct zwp_input_method_v1* input_
     WaylandState* state = static_cast<WaylandState*>(data);
     state->active = true;
 
+    g_ctrl_pressed = false;
+    g_shift_pressed = false;
+    g_alt_pressed = false;
+    g_other_pressed = false;
+
     if (state->keyboard) {
         wl_proxy_destroy((struct wl_proxy*)state->keyboard);
         state->keyboard = nullptr;
@@ -537,6 +567,11 @@ static void input_method_activate(void* data, struct zwp_input_method_v1* input_
 static void input_method_deactivate(void* data, struct zwp_input_method_v1* input_method, struct zwp_input_method_context_v1* context) {
     WaylandState* state = static_cast<WaylandState*>(data);
     state->active = false;
+
+    g_ctrl_pressed = false;
+    g_shift_pressed = false;
+    g_alt_pressed = false;
+    g_other_pressed = false;
     
     if (state->keyboard) {
         wl_proxy_destroy((struct wl_proxy*)state->keyboard);

--- a/wayland-client/src/main.cpp
+++ b/wayland-client/src/main.cpp
@@ -3,13 +3,19 @@
 #include <string.h>
 #include <iostream>
 #include <algorithm>
-#include <vector>
-#include <map>
 #include <set>
 #include <fstream>
 #include <sstream>
+#include <cstdint>
+#include <cstdlib>
 
 static void log_to_file(const std::string& msg) {
+    static const bool enabled = [] {
+        const char* value = getenv("UNIKEY_WAYLAND_DEBUG");
+        return value && strcmp(value, "0") != 0;
+    }();
+    if (!enabled) return;
+
     std::ofstream f("/tmp/uk_debug.log", std::ios::app);
     if (f.is_open()) {
         f << msg << std::endl;
@@ -18,7 +24,6 @@ static void log_to_file(const std::string& msg) {
 
 #include <QApplication>
 #include <QSocketNotifier>
-#include <thread>
 #include "mainwindow.h"
 #include "trayicon.h"
 
@@ -26,6 +31,7 @@ static void log_to_file(const std::string& msg) {
 // No ukengine_wrapper needed
 #include "windowtracker.h"
 #include "libbamboo.h"
+#include "text_transaction.h"
 
 struct WaylandState {
     wl_display* display;
@@ -39,62 +45,17 @@ struct WaylandState {
     bool active;
     uint32_t latest_serial;
     std::string composed_word = "";
-    std::vector<char> raw_keys_normal;
     uint32_t content_purpose = 0;
     
     std::string surrounding_text = "";
     uint32_t surrounding_cursor = 0;
     uint32_t surrounding_anchor = 0;
     bool has_surrounding_text = false;
+    bool surrounding_dirty = false;
+    uint32_t surrounding_serial = 0;
+    uint32_t last_edit_serial = 0;
+    bool edit_pending = false;
 };
-
-static void pop_utf8_char(std::string& str) {
-    if (str.empty()) return;
-    while (!str.empty()) {
-        unsigned char c = str.back();
-        str.pop_back();
-        if ((c & 0xC0) != 0x80) break;
-    }
-}
-
-static int utf8_length(const std::string& str) {
-    int len = 0;
-    for (size_t i = 0; i < str.length(); ++i) {
-        if ((str[i] & 0xC0) != 0x80) len++;
-    }
-    return len;
-}
-
-static int utf8_common_prefix(const std::string& s1, const std::string& s2) {
-    int common = 0;
-    size_t i = 0, j = 0;
-    while (i < s1.length() && j < s2.length()) {
-        int len1 = 1, len2 = 1;
-        while (i + len1 < s1.length() && (s1[i + len1] & 0xC0) == 0x80) len1++;
-        while (j + len2 < s2.length() && (s2[j + len2] & 0xC0) == 0x80) len2++;
-        
-        if (len1 == len2 && s1.substr(i, len1) == s2.substr(j, len2)) {
-            common++;
-            i += len1;
-            j += len2;
-        } else {
-            break;
-        }
-    }
-    return common;
-}
-
-static std::string utf8_substring(const std::string& str, int start_char) {
-    size_t i = 0;
-    int chars = 0;
-    while (i < str.length() && chars < start_char) {
-        int len = 1;
-        while (i + len < str.length() && (str[i + len] & 0xC0) == 0x80) len++;
-        i += len;
-        chars++;
-    }
-    return str.substr(i);
-}
 
 // Evdev keycodes map
 static char get_ascii_from_keycode(uint32_t key, uint32_t mods) {
@@ -152,6 +113,101 @@ WindowTracker* g_windowTracker = nullptr;
 
 static bool g_app_excluded = false;
 
+static void reset_composition(WaylandState* state, bool clear_client_preedit = false) {
+    Bamboo_Reset();
+    if (state) {
+        if (clear_client_preedit && state->context && !state->composed_word.empty()) {
+            zwp_input_method_context_v1_preedit_string(
+                state->context, state->latest_serial, "", "");
+        }
+        state->composed_word.clear();
+    }
+}
+
+static bool has_fresh_surrounding(const WaylandState* state) {
+    return state->has_surrounding_text &&
+           (!state->edit_pending || state->surrounding_serial != state->last_edit_serial);
+}
+
+static void note_text_edit(WaylandState* state) {
+    state->last_edit_serial = state->latest_serial;
+    state->edit_pending = true;
+}
+
+static void predict_surrounding_edit(WaylandState* state,
+                                     const SurroundingReplacement& replacement,
+                                     size_t old_tail_bytes,
+                                     const std::string& suffix) {
+    if (!state->has_surrounding_text) return;
+
+    size_t start = 0;
+    size_t end = 0;
+    if (replacement.uses_surrounding) {
+        start = replacement.start;
+        end = replacement.end;
+    } else {
+        const size_t selection_start = std::min<size_t>(state->surrounding_cursor,
+                                                        state->surrounding_anchor);
+        const size_t selection_end = std::max<size_t>(state->surrounding_cursor,
+                                                      state->surrounding_anchor);
+        if (state->surrounding_cursor > state->surrounding_text.size() ||
+            state->surrounding_anchor > state->surrounding_text.size() ||
+            old_tail_bytes > selection_start) {
+            return;
+        }
+        start = selection_start - old_tail_bytes;
+        end = selection_end;
+    }
+
+    state->surrounding_text.replace(start, end - start, suffix);
+    const size_t cursor = start + suffix.size();
+    state->surrounding_cursor = static_cast<uint32_t>(cursor);
+    state->surrounding_anchor = static_cast<uint32_t>(cursor);
+}
+
+static void replace_native_composition(WaylandState* state,
+                                       const std::string& new_composition) {
+    const std::string old_composition = state->composed_word;
+    const size_t common = utf8_common_prefix_bytes(old_composition, new_composition);
+    const size_t old_tail_bytes = old_composition.size() - common;
+    const std::string suffix = new_composition.substr(common);
+
+    if (old_tail_bytes == 0 && suffix.empty()) {
+        state->composed_word = new_composition;
+        return;
+    }
+
+    SurroundingReplacement replacement;
+    if (state->has_surrounding_text) {
+        replacement = make_surrounding_replacement(old_tail_bytes,
+                                                   state->surrounding_text,
+                                                   state->surrounding_cursor,
+                                                   state->surrounding_anchor);
+    } else {
+        replacement.index = -static_cast<int32_t>(old_tail_bytes);
+        replacement.length = static_cast<uint32_t>(old_tail_bytes);
+    }
+
+    if (old_tail_bytes > 0) {
+        zwp_input_method_context_v1_delete_surrounding_text(
+            state->context, replacement.index, replacement.length);
+    }
+
+    // An empty commit still applies the pending deletion.
+    zwp_input_method_context_v1_commit_string(
+        state->context, state->latest_serial, suffix.c_str());
+    predict_surrounding_edit(state, replacement, old_tail_bytes, suffix);
+    note_text_edit(state);
+    state->composed_word = new_composition;
+}
+
+static std::string bamboo_string(bool final) {
+    char* value = final ? Bamboo_GetCommitString() : Bamboo_GetPreeditString();
+    std::string result = value ? value : "";
+    if (value) free(value);
+    return result;
+}
+
 void show_main_window() {
     if (g_mainWindow) {
         QMetaObject::invokeMethod(g_mainWindow, []() {
@@ -201,6 +257,7 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
         int switchKeyConfig = g_mainWindow ? g_mainWindow->getSwitchKey() : 0;
         if (key == 29 || key == 97) {
             if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed && !g_switched) {
+                reset_composition(state, true);
                 if (g_mainWindow) {
                     g_mainWindow->setVietMode(!state->viet_mode);
                 } else {
@@ -215,6 +272,7 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
             }
         } else if (key == 42 || key == 54) {
             if (switchKeyConfig == 0 && g_ctrl_pressed && g_shift_pressed && !g_other_pressed && !g_switched) {
+                reset_composition(state, true);
                 if (g_mainWindow) {
                     g_mainWindow->setVietMode(!state->viet_mode);
                 } else {
@@ -239,6 +297,7 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
     int switchKeyConfig = g_mainWindow ? g_mainWindow->getSwitchKey() : 0;
     bool real_alt_pressed = (g_modifiers & 8) != 0; // Better check to avoid sticky Alt bug
     if (switchKeyConfig == 1 && key == 44 && real_alt_pressed && state_key == 1) {
+        reset_composition(state, true);
         if (g_mainWindow) {
             g_mainWindow->setVietMode(!state->viet_mode);
         } else {
@@ -279,8 +338,7 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
 
     if (!state->viet_mode) {
         log_to_file("DEBUG: Forwarding in E mode");
-        Bamboo_Reset();
-        state->composed_word.clear();
+        reset_composition(state, true);
         zwp_input_method_context_v1_key(state->context, serial, time, key, state_key);
         return;
     }
@@ -310,29 +368,28 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
                     zwp_input_method_context_v1_preedit_styling(state->context, 0, byte_len, 5);
                     zwp_input_method_context_v1_preedit_string(state->context, state->latest_serial, new_preedit, new_preedit);
                 }
+                state->composed_word = new_preedit ? new_preedit : "";
                 if (new_preedit) free(new_preedit);
                 eaten_keys.insert(key);
                 return;
             }
             
             if (!Bamboo_CanProcessKey(c)) {
-                char* commit_str = Bamboo_GetCommitString();
-                zwp_input_method_context_v1_preedit_string(state->context, state->latest_serial, "", "");
-                std::string final_commit = commit_str ? commit_str : "";
-                if (commit_str) free(commit_str);
+                std::string final_commit = bamboo_string(true);
                 
                 // Gõ tắt (Macro)
                 if (g_mainWindow && g_mainWindow->isMacroEnabled()) {
-                    auto macros = g_mainWindow->getMacros();
-                    if (macros.find(final_commit) != macros.end()) {
-                        final_commit = macros[final_commit];
+                    const auto& macros = g_mainWindow->getMacros();
+                    auto macro = macros.find(final_commit);
+                    if (macro != macros.end()) {
+                        final_commit = macro->second;
                     }
                 }
                 
                 if (final_commit.length() > 0) {
                     zwp_input_method_context_v1_commit_string(state->context, state->latest_serial, final_commit.c_str());
                 }
-                Bamboo_Reset();
+                reset_composition(state);
                 
                 zwp_input_method_context_v1_key(state->context, serial, time, key, state_key);
                 return;
@@ -348,12 +405,21 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
                 zwp_input_method_context_v1_preedit_cursor(state->context, byte_len);
                 zwp_input_method_context_v1_preedit_styling(state->context, 0, byte_len, 5);
                 zwp_input_method_context_v1_preedit_string(state->context, state->latest_serial, preedit_str, preedit_str);
+                state->composed_word = preedit_str;
                 free(preedit_str);
                 eaten_keys.insert(key);
                 return;
             }
         } else {
             // Normal Mode (Chrome, Gtk, Qt apps) - Use Bamboo Diffing
+            if (has_fresh_surrounding(state) &&
+                !composition_matches_surrounding(state->surrounding_text,
+                                                 state->surrounding_cursor,
+                                                 state->surrounding_anchor,
+                                                 state->composed_word)) {
+                reset_composition(state);
+            }
+
             if (c == '\b') {
                 if (state->composed_word.empty()) {
                     zwp_input_method_context_v1_key(state->context, serial, time, key, state_key);
@@ -361,100 +427,40 @@ static void keyboard_key(void* data, struct wl_keyboard* keyboard, uint32_t seri
                 }
                 Bamboo_RemoveLastChar();
             } else if (!Bamboo_CanProcessKey(c)) {
-                std::string current_word = state->composed_word;
-                Bamboo_Reset();
-                state->composed_word.clear();
+                std::string final_word = bamboo_string(true);
                 
                 // Gõ tắt (Macro)
                 if (g_mainWindow && g_mainWindow->isMacroEnabled()) {
-                    auto macros = g_mainWindow->getMacros();
-                    if (macros.find(current_word) != macros.end()) {
-                        std::string macro_val = macros[current_word];
-                        int byte_backs = current_word.length();
-                        if (byte_backs > 0) {
-                            zwp_input_method_context_v1_delete_surrounding_text(state->context, -byte_backs, byte_backs);
-                        }
-                        zwp_input_method_context_v1_commit_string(state->context, state->latest_serial, macro_val.c_str());
+                    const auto& macros = g_mainWindow->getMacros();
+                    auto macro = macros.find(final_word);
+                    if (macro != macros.end()) {
+                        final_word = macro->second;
                     }
                 }
-                
+
+                replace_native_composition(state, final_word);
+                reset_composition(state);
                 zwp_input_method_context_v1_key(state->context, serial, time, key, state_key);
                 return;
             } else {
                 Bamboo_ProcessKey(c);
             }
-            
-            char* preedit_str = Bamboo_GetPreeditString();
-            std::string new_composed = preedit_str ? preedit_str : "";
-            if (preedit_str) free(preedit_str);
-            
-            int common_bytes = 0;
-            size_t i = 0, j = 0;
-            while (i < state->composed_word.length() && j < new_composed.length()) {
-                int len1 = 1, len2 = 1;
-                while (i + len1 < state->composed_word.length() && (state->composed_word[i + len1] & 0xC0) == 0x80) len1++;
-                while (j + len2 < new_composed.length() && (new_composed[j + len2] & 0xC0) == 0x80) len2++;
-                
-                if (len1 == len2 && state->composed_word.substr(i, len1) == new_composed.substr(j, len2)) {
-                    common_bytes += len1;
-                    i += len1;
-                    j += len2;
-                } else {
-                    break;
-                }
-            }
 
-            int byte_backs = state->composed_word.length() - common_bytes;
-            if (byte_backs > 0) {
-                // Giải pháp Hybrid:
-                // Trình duyệt Chrome có một lỗi toán học khiến delete_surrounding_text bị hỏng nếu có vùng bôi đen ngược.
-                // Do đó, nếu phát hiện có vùng bôi đen (Chrome Omnibox), ta dùng phím Backspace mô phỏng chỉ riêng cho lúc này.
-                // Các trường hợp gõ bình thường khác, ta vẫn dùng delete_surrounding_text để đảm bảo mượt mà 100%.
-                if (state->has_surrounding_text && state->surrounding_cursor != state->surrounding_anchor) {
-                    int chars_to_delete = 0;
-                    size_t idx = common_bytes;
-                    while (idx < state->composed_word.length()) {
-                        chars_to_delete++;
-                        idx++;
-                        while (idx < state->composed_word.length() && (state->composed_word[idx] & 0xC0) == 0x80) idx++;
-                    }
-                    // +1 Backspace để phá vỡ vùng bôi đen
-                    chars_to_delete++;
-                    for (int k = 0; k < chars_to_delete; k++) {
-                        zwp_input_method_context_v1_key(state->context, state->latest_serial, time, 14, 1);
-                        zwp_input_method_context_v1_key(state->context, state->latest_serial, time, 14, 0);
-                    }
-                    // Xóa bôi đen nội bộ để không bị lặp lại nếu Wayland chậm
-                    state->surrounding_cursor = state->surrounding_anchor;
-                } else {
-                    zwp_input_method_context_v1_delete_surrounding_text(state->context, -byte_backs, byte_backs);
-                }
-            }
-
-            std::string suffix = new_composed.substr(common_bytes);
-            if (!suffix.empty()) {
-                zwp_input_method_context_v1_commit_string(state->context, state->latest_serial, suffix.c_str());
-            }
-
-            // Đã commit_string ở trên rồi nên không cần làm gì thêm ở đây nữa
-            state->composed_word = new_composed;
+            replace_native_composition(state, bamboo_string(false));
             eaten_keys.insert(key);
             return;
         }
     } else {
         // c == 0 (Phím chức năng, phím tắt Ctrl, Alt, Arrow, Esc...)
         if (state->content_purpose == 12 || g_app_excluded) {
-            char* preedit = Bamboo_GetPreeditString();
-            if (preedit && strlen(preedit) > 0) {
-                zwp_input_method_context_v1_commit_string(state->context, state->latest_serial, preedit);
-                zwp_input_method_context_v1_preedit_string(state->context, state->latest_serial, "", "");
-                Bamboo_Reset();
+            std::string final_commit = bamboo_string(true);
+            if (!final_commit.empty()) {
+                zwp_input_method_context_v1_commit_string(
+                    state->context, state->latest_serial, final_commit.c_str());
             }
-            if (preedit) free(preedit);
+            reset_composition(state);
         } else {
-            Bamboo_Reset();
-            state->composed_word.clear();
-            state->raw_keys_normal.clear();
+            reset_composition(state);
         }
     }
     
@@ -497,12 +503,15 @@ static void input_method_context_surrounding_text(void* data, struct zwp_input_m
     state->surrounding_cursor = cursor;
     state->surrounding_anchor = anchor;
     state->has_surrounding_text = true;
+    state->surrounding_dirty = true;
 }
 static void input_method_context_reset(void* data, struct zwp_input_method_context_v1* context) {
     WaylandState* state = static_cast<WaylandState*>(data);
     if (state) {
-        Bamboo_Reset();
-        state->composed_word.clear();
+        reset_composition(state);
+        state->has_surrounding_text = false;
+        state->surrounding_dirty = false;
+        state->edit_pending = false;
     }
 }
 static void input_method_context_content_type(void* data, struct zwp_input_method_context_v1* context, uint32_t hint, uint32_t purpose) {
@@ -519,6 +528,13 @@ static void input_method_context_invoke_action(void* data, struct zwp_input_meth
 static void input_method_context_commit_state(void* data, struct zwp_input_method_context_v1* context, uint32_t serial) {
     WaylandState* state = static_cast<WaylandState*>(data);
     state->latest_serial = serial;
+    if (state->surrounding_dirty) {
+        state->surrounding_serial = serial;
+        state->surrounding_dirty = false;
+    }
+    if (state->edit_pending && serial != state->last_edit_serial) {
+        state->edit_pending = false;
+    }
 }
 
 static void input_method_context_preferred_language(void* data, struct zwp_input_method_context_v1* context, const char* language) {}
@@ -542,6 +558,12 @@ static void input_method_activate(void* data, struct zwp_input_method_v1* input_
     g_shift_pressed = false;
     g_alt_pressed = false;
     g_other_pressed = false;
+    eaten_keys.clear();
+    reset_composition(state);
+    state->content_purpose = 0;
+    state->has_surrounding_text = false;
+    state->surrounding_dirty = false;
+    state->edit_pending = false;
 
     if (state->keyboard) {
         wl_proxy_destroy((struct wl_proxy*)state->keyboard);
@@ -572,6 +594,11 @@ static void input_method_deactivate(void* data, struct zwp_input_method_v1* inpu
     g_shift_pressed = false;
     g_alt_pressed = false;
     g_other_pressed = false;
+    eaten_keys.clear();
+    reset_composition(state);
+    state->has_surrounding_text = false;
+    state->surrounding_dirty = false;
+    state->edit_pending = false;
     
     if (state->keyboard) {
         wl_proxy_destroy((struct wl_proxy*)state->keyboard);
@@ -653,13 +680,15 @@ int main(int argc, char **argv) {
     WindowTracker windowTracker;
     g_windowTracker = &windowTracker;
     QObject::connect(&windowTracker, &WindowTracker::activeWindowChangedSignal, [&](const QString& windowClass) {
+        const bool was_excluded = g_app_excluded;
         g_app_excluded = windowTracker.isAppExcluded(windowClass.toStdString());
+        if (was_excluded != g_app_excluded) {
+            reset_composition(&state, true);
+        }
         if (g_app_excluded) {
             std::stringstream ss;
             ss << "DEBUG: Application excluded: " << windowClass.toStdString();
             log_to_file(ss.str());
-            state.composed_word.clear();
-            Bamboo_Reset();
         }
     });
 
@@ -682,15 +711,23 @@ int main(int argc, char **argv) {
 
     log_to_file("Wayland IM v1 Client started with Qt GUI. Waiting for events...");
 
+    QSocketNotifier* waylandNotifier = nullptr;
     if (state.display) {
-        std::thread wayland_thread([&state]() {
-            while (state.display) {
-                if (wl_display_dispatch(state.display) == -1) {
-                    break;
-                }
+        waylandNotifier = new QSocketNotifier(
+            wl_display_get_fd(state.display), QSocketNotifier::Read, &app);
+        QObject::connect(waylandNotifier, &QSocketNotifier::activated,
+                         [&state, &app, waylandNotifier]() {
+            if (wl_display_dispatch(state.display) == -1) {
+                waylandNotifier->setEnabled(false);
+                std::cerr << "Wayland display disconnected or error." << std::endl;
+                app.quit();
+                return;
             }
+            while (wl_display_dispatch_pending(state.display) > 0) {}
+            wl_display_flush(state.display);
         });
-        wayland_thread.detach();
+        while (wl_display_dispatch_pending(state.display) > 0) {}
+        wl_display_flush(state.display);
     }
 
     int ret = app.exec();

--- a/wayland-client/src/main.cpp
+++ b/wayland-client/src/main.cpp
@@ -18,6 +18,7 @@ static void log_to_file(const std::string& msg) {
 
 #include <QApplication>
 #include <QSocketNotifier>
+#include <thread>
 #include "mainwindow.h"
 #include "trayicon.h"
 
@@ -508,6 +509,7 @@ static const struct zwp_input_method_context_v1_listener input_method_context_li
 
 
 static void input_method_activate(void* data, struct zwp_input_method_v1* input_method, struct zwp_input_method_context_v1* context) {
+    log_to_file("DEBUG: input_method_activate triggered by KWin!");
     WaylandState* state = static_cast<WaylandState*>(data);
     state->active = true;
 
@@ -525,7 +527,10 @@ static void input_method_activate(void* data, struct zwp_input_method_v1* input_
     
     state->keyboard = zwp_input_method_context_v1_grab_keyboard(state->context);
     if (state->keyboard) {
+        log_to_file("DEBUG: grab_keyboard succeeded! Adding keyboard listener.");
         wl_keyboard_add_listener(state->keyboard, &keyboard_listener, state);
+    } else {
+        log_to_file("ERROR: grab_keyboard returned NULL!");
     }
 }
 
@@ -569,15 +574,27 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 int main(int argc, char **argv) {
-    Bamboo_Init(); // KÍCH HOẠT NÃO CGO BAMBOO
-    
-    setenv("QT_QPA_PLATFORM", "wayland;xcb", 0); // Prefer Wayland, fallback to xcb. 0 means don't overwrite if user explicitly set it.
+    Bamboo_Init();
+    int im_socket_fd = -1;
+    char* wayland_socket_env = getenv("WAYLAND_SOCKET");
+    if (wayland_socket_env) {
+        int orig_fd = atoi(wayland_socket_env);
+        im_socket_fd = dup(orig_fd);
+        unsetenv("WAYLAND_SOCKET");
+    }
+
+    setenv("QT_QPA_PLATFORM", "wayland;xcb", 0); // Prefer Wayland, fallback to xcb.
     QApplication app(argc, argv);
     app.setQuitOnLastWindowClosed(false);
 
     WaylandState state = {};
 
-    state.display = wl_display_connect(NULL);
+    if (im_socket_fd >= 0) {
+        state.display = wl_display_connect_to_fd(im_socket_fd);
+    } else {
+        state.display = wl_display_connect(NULL);
+    }
+
     if (!state.display) {
         std::cerr << "Failed to connect to Wayland display. Running in GUI-only mode." << std::endl;
     } else {
@@ -593,8 +610,7 @@ int main(int argc, char **argv) {
         zwp_input_method_v1_add_listener(state.input_method, &input_method_listener, &state);
     }
 
-    bool is_gnome_edition = !has_wayland_im;
-    app.setQuitOnLastWindowClosed(is_gnome_edition);
+    bool is_gnome_edition = false;
 
     MainWindow mainWindow(&state.viet_mode, is_gnome_edition);
     g_mainWindow = &mainWindow;
@@ -614,10 +630,7 @@ int main(int argc, char **argv) {
 
     windowTracker.injectKWinScript();
 
-    TrayIcon* trayIcon = nullptr;
-    if (!is_gnome_edition) {
-        trayIcon = new TrayIcon(&state.viet_mode, &mainWindow, is_gnome_edition);
-    }
+    TrayIcon* trayIcon = new TrayIcon(&state.viet_mode, &mainWindow, false);
 
     bool showExclude = false;
     if (argc > 1) {
@@ -634,25 +647,15 @@ int main(int argc, char **argv) {
 
     log_to_file("Wayland IM v1 Client started with Qt GUI. Waiting for events...");
 
-    QSocketNotifier* notifier = nullptr;
     if (state.display) {
-        int fd = wl_display_get_fd(state.display);
-        notifier = new QSocketNotifier(fd, QSocketNotifier::Read, &app);
-        QObject::connect(notifier, &QSocketNotifier::activated, [&state, &app]() {
-            if (wl_display_dispatch(state.display) == -1) {
-                std::cerr << "Wayland display disconnected or error." << std::endl;
-                app.quit();
-                return;
+        std::thread wayland_thread([&state]() {
+            while (state.display) {
+                if (wl_display_dispatch(state.display) == -1) {
+                    break;
+                }
             }
-            while (wl_display_dispatch_pending(state.display) > 0) {
-                // Keep dispatching pending events
-            }
-            wl_display_flush(state.display);
         });
-
-        // We must dispatch any pending events before entering the event loop
-        while (wl_display_dispatch_pending(state.display) > 0) {}
-        wl_display_flush(state.display);
+        wayland_thread.detach();
     }
 
     int ret = app.exec();

--- a/wayland-client/src/mainwindow.cpp
+++ b/wayland-client/src/mainwindow.cpp
@@ -17,6 +17,7 @@
 #include <QFileInfo>
 #include <QPlainTextEdit>
 #include "windowtracker.h"
+#include "libbamboo.h"
 
 MainWindow::MainWindow(bool* p_viet_mode, bool is_gnome, QWidget *parent)
     : QWidget(parent), p_viet_mode(p_viet_mode) {
@@ -184,8 +185,7 @@ void MainWindow::applySettings() {
     int method = m_methodCombo->currentData().toInt();
     int charset = m_charsetCombo->currentData().toInt();
     
-    // Toàn bộ logic tùy chọn phức tạp đã được thay bằng Bamboo CGO hiện đại.
-    // Các UI này giữ lại để không phá vỡ layout, nhưng không cần làm gì ở đây.
+    Bamboo_SetInputMethod(method);
 
     saveConfig();
 }

--- a/wayland-client/src/mainwindow.cpp
+++ b/wayland-client/src/mainwindow.cpp
@@ -16,6 +16,8 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QPlainTextEdit>
+#include <QDBusMessage>
+#include <QDBusConnection>
 #include "windowtracker.h"
 #include "libbamboo.h"
 
@@ -212,6 +214,15 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 void MainWindow::setVietMode(bool viet) {
     if (p_viet_mode) *p_viet_mode = viet;
     saveConfig();
+
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        "org.kde.plasmashell",
+        "/org/kde/osdService",
+        "org.kde.osdService",
+        "showText"
+    );
+    msg << QString("input-keyboard") << QString(viet ? "UniKey: Tiếng Việt [V]" : "UniKey: Tiếng Anh [E]");
+    QDBusConnection::sessionBus().send(msg);
 }
 
 QString MainWindow::getConfigPath() const {

--- a/wayland-client/src/mainwindow.cpp
+++ b/wayland-client/src/mainwindow.cpp
@@ -187,7 +187,13 @@ void MainWindow::applySettings() {
     int method = m_methodCombo->currentData().toInt();
     int charset = m_charsetCombo->currentData().toInt();
     
+    bool freeMarking = m_freeMarkingCheck->isChecked();
+    bool modernStyle = m_modernStyleCheck->isChecked();
+    bool autoRestore = m_autoRestoreCheck->isChecked();
+    bool spellCheck = m_spellCheckCheck->isChecked();
+
     Bamboo_SetInputMethod(method);
+    Bamboo_SetOptions(freeMarking, modernStyle, spellCheck, autoRestore);
 
     saveConfig();
 }
@@ -283,7 +289,7 @@ void MainWindow::loadConfig() {
         preeditFile.close();
     } else {
         // Default list
-        QString defaults = "kitty\nalacritty\nkonsole\ngnome-terminal\nxfce4-terminal\nlxterminal\nstudio\njava";
+        QString defaults = "kitty\nalacritty\nkonsole\ngnome-terminal\nxfce4-terminal\nlxterminal\nandroid-studio\njava";
         m_preeditAppsTextEdit->setPlainText(defaults);
         QDir().mkpath(QFileInfo(preeditPath).absolutePath());
         if (preeditFile.open(QIODevice::WriteOnly | QIODevice::Text)) {

--- a/wayland-client/src/text_transaction.h
+++ b/wayland-client/src/text_transaction.h
@@ -1,0 +1,72 @@
+#ifndef TEXT_TRANSACTION_H
+#define TEXT_TRANSACTION_H
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+struct SurroundingReplacement {
+    int32_t index = 0;
+    uint32_t length = 0;
+    size_t start = 0;
+    size_t end = 0;
+    bool uses_surrounding = false;
+};
+
+inline size_t utf8_common_prefix_bytes(const std::string& left, const std::string& right) {
+    size_t common = 0;
+    while (common < left.size() && common < right.size() && left[common] == right[common]) {
+        ++common;
+    }
+    while (common > 0 && common < left.size() &&
+           (static_cast<unsigned char>(left[common]) & 0xC0) == 0x80) {
+        --common;
+    }
+    return common;
+}
+
+inline bool composition_matches_surrounding(const std::string& text,
+                                            uint32_t cursor,
+                                            uint32_t anchor,
+                                            const std::string& composition) {
+    if (composition.empty()) return true;
+    const size_t insertion = std::min<size_t>(cursor, anchor);
+    if (cursor > text.size() || anchor > text.size() || insertion < composition.size()) {
+        return false;
+    }
+    return text.compare(insertion - composition.size(), composition.size(), composition) == 0;
+}
+
+// The delete range must cover the current selection.
+inline SurroundingReplacement make_surrounding_replacement(size_t old_tail_bytes,
+                                                            const std::string& text,
+                                                            uint32_t cursor,
+                                                            uint32_t anchor) {
+    SurroundingReplacement result;
+    result.index = -static_cast<int32_t>(old_tail_bytes);
+    result.length = static_cast<uint32_t>(old_tail_bytes);
+
+    if (cursor > text.size() || anchor > text.size()) return result;
+    const size_t selection_start = std::min<size_t>(cursor, anchor);
+    const size_t selection_end = std::max<size_t>(cursor, anchor);
+    if (old_tail_bytes > selection_start) return result;
+
+    const size_t start = selection_start - old_tail_bytes;
+    const size_t length = selection_end - start;
+    const int64_t index = static_cast<int64_t>(start) - static_cast<int64_t>(cursor);
+    if (index < std::numeric_limits<int32_t>::min() ||
+        index > std::numeric_limits<int32_t>::max() ||
+        length > std::numeric_limits<uint32_t>::max()) {
+        return result;
+    }
+
+    result.index = static_cast<int32_t>(index);
+    result.length = static_cast<uint32_t>(length);
+    result.start = start;
+    result.end = selection_end;
+    result.uses_surrounding = true;
+    return result;
+}
+
+#endif // TEXT_TRANSACTION_H

--- a/wayland-client/src/trayicon.cpp
+++ b/wayland-client/src/trayicon.cpp
@@ -39,8 +39,10 @@ void StatusNotifierItemAdaptor::ContextMenu(int x, int y) {
     tray->onShowControlPanel();
 }
 
+#include <QDBusServiceWatcher>
+
 TrayIcon::TrayIcon(bool* p_viet_mode, MainWindow* mainWindow, bool is_gnome, QObject* parent)
-    : QObject(parent), p_viet_mode(p_viet_mode), m_mainWindow(mainWindow), m_isGnome(is_gnome), m_dbusAdaptor(nullptr) {
+    : QObject(parent), p_viet_mode(p_viet_mode), m_mainWindow(mainWindow), m_isGnome(is_gnome), m_dbusAdaptor(nullptr), m_serviceWatcher(nullptr) {
 
     m_trayMenu = new QMenu();
     m_actionControlPanel = m_trayMenu->addAction("Bảng điều khiển... [CS+F5]");
@@ -55,18 +57,38 @@ TrayIcon::TrayIcon(bool* p_viet_mode, MainWindow* mainWindow, bool is_gnome, QOb
     if (bus.isConnected()) {
         m_dbusAdaptor = new StatusNotifierItemAdaptor(this);
         bus.registerObject("/StatusNotifierItem", this, QDBusConnection::ExportAdaptors);
-        
-        QDBusMessage msg = QDBusMessage::createMethodCall(
+
+        // Watch for StatusNotifierWatcher (in case Plasma/Watcher starts after Unikey or restarts)
+        m_serviceWatcher = new QDBusServiceWatcher(
+            "org.kde.StatusNotifierWatcher",
+            bus,
+            QDBusServiceWatcher::WatchForOwnerChange | QDBusServiceWatcher::WatchForRegistration,
+            this
+        );
+        connect(m_serviceWatcher, &QDBusServiceWatcher::serviceRegistered, this, &TrayIcon::registerWithWatcher);
+        connect(m_serviceWatcher, &QDBusServiceWatcher::serviceOwnerChanged, this, [this](const QString&, const QString&, const QString& newOwner) {
+            if (!newOwner.isEmpty()) {
+                registerWithWatcher();
+            }
+        });
+
+        // Listen for new tray hosts registering (e.g. system tray reloaded/restarted)
+        bus.connect(
             "org.kde.StatusNotifierWatcher",
             "/StatusNotifierWatcher",
             "org.kde.StatusNotifierWatcher",
-            "RegisterStatusNotifierItem"
+            "StatusNotifierHostRegistered",
+            this,
+            SLOT(registerWithWatcher())
         );
-        msg << "/StatusNotifierItem";
-        bus.call(msg);
-    }
 
-    updateIcon();
+        // Register immediately
+        registerWithWatcher();
+
+        // Extra retry shots for slow startup race conditions
+        QTimer::singleShot(500, this, &TrayIcon::registerWithWatcher);
+        QTimer::singleShot(1500, this, &TrayIcon::registerWithWatcher);
+    }
 
     QTimer* timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, &TrayIcon::updateIcon);
@@ -75,6 +97,26 @@ TrayIcon::TrayIcon(bool* p_viet_mode, MainWindow* mainWindow, bool is_gnome, QOb
 
 TrayIcon::~TrayIcon() {
     delete m_trayMenu;
+}
+
+void TrayIcon::registerWithWatcher() {
+    QDBusConnection bus = QDBusConnection::sessionBus();
+    if (!bus.isConnected()) return;
+
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        "org.kde.StatusNotifierWatcher",
+        "/StatusNotifierWatcher",
+        "org.kde.StatusNotifierWatcher",
+        "RegisterStatusNotifierItem"
+    );
+    msg << "/StatusNotifierItem";
+    bus.call(msg);
+
+    if (m_dbusAdaptor) {
+        emit m_dbusAdaptor->NewIcon();
+        emit m_dbusAdaptor->NewTitle();
+        emit m_dbusAdaptor->NewStatus(QString("Active"));
+    }
 }
 
 void TrayIcon::toggleMode() {

--- a/wayland-client/src/trayicon.cpp
+++ b/wayland-client/src/trayicon.cpp
@@ -4,125 +4,98 @@
 #include <QPixmap>
 #include <QColor>
 #include <QFont>
+#include <QTimer>
+#include <QElapsedTimer>
+#include <QDBusConnection>
+#include <QDBusMessage>
 
-static QIcon createIconWithText(const QString& text, QColor bgColor, QColor textColor) {
-    QPixmap pixmap(64, 64);
-    pixmap.fill(Qt::transparent);
-
-    QPainter painter(&pixmap);
-    painter.setRenderHint(QPainter::Antialiasing);
-
-    // Draw rounded rect background
-    painter.setBrush(bgColor);
-    painter.setPen(Qt::NoPen);
-    painter.drawRoundedRect(4, 4, 56, 56, 12, 12);
-
-    // Draw text
-    painter.setPen(textColor);
-    QFont font = painter.font();
-    font.setPixelSize(48);
-    font.setBold(true);
-    painter.setFont(font);
-    painter.drawText(pixmap.rect(), Qt::AlignCenter, text);
-
-    return QIcon(pixmap);
+StatusNotifierItemAdaptor::StatusNotifierItemAdaptor(TrayIcon* parent)
+    : QDBusAbstractAdaptor(parent) {
 }
 
-#include <QTimer>
+QString StatusNotifierItemAdaptor::iconName() const {
+    TrayIcon* tray = static_cast<TrayIcon*>(parent());
+    return tray->isVietMode() ? "unikey-wayland-v" : "unikey-wayland-e";
+}
+
+void StatusNotifierItemAdaptor::Activate(int x, int y) {
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+    TrayIcon* tray = static_cast<TrayIcon*>(parent());
+    tray->toggleMode();
+}
+
+void StatusNotifierItemAdaptor::SecondaryActivate(int x, int y) {
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+    TrayIcon* tray = static_cast<TrayIcon*>(parent());
+    tray->onShowControlPanel();
+}
+
+void StatusNotifierItemAdaptor::ContextMenu(int x, int y) {
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+    TrayIcon* tray = static_cast<TrayIcon*>(parent());
+    tray->onShowControlPanel();
+}
 
 TrayIcon::TrayIcon(bool* p_viet_mode, MainWindow* mainWindow, bool is_gnome, QObject* parent)
-    : QObject(parent), p_viet_mode(p_viet_mode), m_mainWindow(mainWindow), m_isGnome(is_gnome) {
-    
-    // Create icons dynamically
-    m_iconV = createIconWithText("V", QColor(220, 53, 69), Qt::white); // Red background for V
-    m_iconE = createIconWithText("E", QColor(0, 123, 255), Qt::white); // Blue background for E
+    : QObject(parent), p_viet_mode(p_viet_mode), m_mainWindow(mainWindow), m_isGnome(is_gnome), m_dbusAdaptor(nullptr) {
 
-    m_trayIcon = new QSystemTrayIcon(this);
-    
     m_trayMenu = new QMenu();
     m_actionControlPanel = m_trayMenu->addAction("Bảng điều khiển... [CS+F5]");
     m_trayMenu->addSeparator();
-
-
-
-    m_trayMenu->addSeparator();
     m_actionQuit = m_trayMenu->addAction("Kết thúc");
 
-    m_trayIcon->setContextMenu(m_trayMenu);
-
-    connect(m_trayIcon, &QSystemTrayIcon::activated, this, &TrayIcon::onTrayIconActivated);
     connect(m_actionControlPanel, &QAction::triggered, this, &TrayIcon::onShowControlPanel);
     connect(m_actionQuit, &QAction::triggered, this, &TrayIcon::onQuit);
 
-    updateIcon();
-    m_trayIcon->show();
+    // Register DBus StatusNotifierItem directly for KDE Plasma Wayland taskbar
+    QDBusConnection bus = QDBusConnection::sessionBus();
+    if (bus.isConnected()) {
+        m_dbusAdaptor = new StatusNotifierItemAdaptor(this);
+        bus.registerObject("/StatusNotifierItem", this, QDBusConnection::ExportAdaptors);
+        
+        QDBusMessage msg = QDBusMessage::createMethodCall(
+            "org.kde.StatusNotifierWatcher",
+            "/StatusNotifierWatcher",
+            "org.kde.StatusNotifierWatcher",
+            "RegisterStatusNotifierItem"
+        );
+        msg << "/StatusNotifierItem";
+        bus.call(msg);
+    }
 
-    // Start timer to poll status for hotkey updates
+    updateIcon();
+
     QTimer* timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, &TrayIcon::updateIcon);
     timer->start(100);
 }
 
 TrayIcon::~TrayIcon() {
-    delete m_trayIcon;
     delete m_trayMenu;
 }
 
-void TrayIcon::updateIcon() {
-    static bool lastMode = !(*p_viet_mode); // Force initial update
-    bool currentMode = *p_viet_mode;
-    if (currentMode == lastMode) return; // Avoid setting icon unnecessarily
-    lastMode = currentMode;
-
-    bool isViet = p_viet_mode ? *p_viet_mode : true;
-    if (m_isGnome) {
-        if (isViet) {
-            m_trayIcon->setIcon(QIcon::fromTheme("unikey-vietnamese", QIcon(":/icons/unikey-vietnamese.png")));
-        } else {
-            m_trayIcon->setIcon(QIcon::fromTheme("unikey-english", QIcon(":/icons/unikey-english.png")));
-        }
-    } else {
-        if (isViet) {
-            m_trayIcon->setIcon(m_iconV);
-            m_trayIcon->setToolTip("UniKey - Vietnamese");
-        } else {
-            m_trayIcon->setIcon(m_iconE);
-            m_trayIcon->setToolTip("UniKey - English");
+void TrayIcon::toggleMode() {
+    if (p_viet_mode) {
+        *p_viet_mode = !(*p_viet_mode);
+        if (m_mainWindow) {
+            m_mainWindow->setVietMode(*p_viet_mode);
         }
     }
+    updateIcon();
 }
 
-#include <QElapsedTimer>
+void TrayIcon::updateIcon() {
+    static bool lastMode = !(*p_viet_mode);
+    bool currentMode = *p_viet_mode;
+    if (currentMode == lastMode) return;
+    lastMode = currentMode;
 
-void TrayIcon::onTrayIconActivated(QSystemTrayIcon::ActivationReason reason) {
-    static QElapsedTimer clickTimer;
-    
-    if (reason == QSystemTrayIcon::Trigger) {
-        if (m_isGnome) {
-            onShowControlPanel();
-            return;
-        }
-
-        if (clickTimer.isValid() && clickTimer.elapsed() < 400) {
-            // Double click detected via timing!
-            // Undo the first click's toggle by toggling again
-            if (p_viet_mode) {
-                *p_viet_mode = !(*p_viet_mode);
-                m_mainWindow->setVietMode(*p_viet_mode);
-            }
-            updateIcon();
-            onShowControlPanel();
-        } else {
-            // Single click: toggle E/V
-            if (p_viet_mode) {
-                *p_viet_mode = !(*p_viet_mode);
-                m_mainWindow->setVietMode(*p_viet_mode);
-            }
-            updateIcon();
-        }
-        clickTimer.restart();
-    } else if (reason == QSystemTrayIcon::DoubleClick || reason == QSystemTrayIcon::MiddleClick) {
-        onShowControlPanel();
+    if (m_dbusAdaptor) {
+        emit m_dbusAdaptor->NewIcon();
+        emit m_dbusAdaptor->NewTitle();
     }
 }
 
@@ -133,7 +106,6 @@ void TrayIcon::onShowControlPanel() {
         m_mainWindow->activateWindow();
     }
 }
-
 
 void TrayIcon::onQuit() {
     QApplication::quit();

--- a/wayland-client/src/trayicon.h
+++ b/wayland-client/src/trayicon.h
@@ -46,6 +46,8 @@ signals:
     void NewStatus(const QString& status);
 };
 
+class QDBusServiceWatcher;
+
 class TrayIcon : public QObject {
     Q_OBJECT
 public:
@@ -57,6 +59,7 @@ public:
     void toggleMode();
 
 public slots:
+    void registerWithWatcher();
     void onShowControlPanel();
     void onQuit();
 
@@ -69,6 +72,7 @@ private:
     QAction* m_actionQuit;
 
     StatusNotifierItemAdaptor* m_dbusAdaptor = nullptr;
+    QDBusServiceWatcher* m_serviceWatcher = nullptr;
 };
 
 #endif // TRAYICON_H

--- a/wayland-client/src/trayicon.h
+++ b/wayland-client/src/trayicon.h
@@ -1,10 +1,50 @@
 #ifndef TRAYICON_H
 #define TRAYICON_H
 
+#include <QObject>
 #include <QSystemTrayIcon>
 #include <QMenu>
 #include <QAction>
+#include <QDBusAbstractAdaptor>
+#include <QDBusConnection>
+#include <QDBusMessage>
 #include "mainwindow.h"
+
+class TrayIcon;
+
+class StatusNotifierItemAdaptor : public QDBusAbstractAdaptor {
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.kde.StatusNotifierItem")
+    Q_PROPERTY(QString Category READ category)
+    Q_PROPERTY(QString Id READ id)
+    Q_PROPERTY(QString Title READ title)
+    Q_PROPERTY(QString Status READ status)
+    Q_PROPERTY(QString IconName READ iconName)
+    Q_PROPERTY(QString IconThemePath READ iconThemePath)
+    Q_PROPERTY(bool ItemIsMenu READ itemIsMenu)
+
+public:
+    explicit StatusNotifierItemAdaptor(TrayIcon* parent);
+
+    QString category() const { return "ApplicationStatus"; }
+    QString id() const { return "unikey-wayland"; }
+    QString title() const { return "UniKey"; }
+    QString status() const { return "Active"; }
+    QString iconName() const;
+    QString iconThemePath() const { return "/home/quan/.local/share/icons"; }
+    bool itemIsMenu() const { return false; }
+
+public slots:
+    void ContextMenu(int x, int y);
+    void Activate(int x, int y);
+    void SecondaryActivate(int x, int y);
+    void Scroll(int delta, const QString& orientation) { Q_UNUSED(delta); Q_UNUSED(orientation); }
+
+signals:
+    void NewTitle();
+    void NewIcon();
+    void NewStatus(const QString& status);
+};
 
 class TrayIcon : public QObject {
     Q_OBJECT
@@ -13,9 +53,10 @@ public:
     ~TrayIcon();
 
     void updateIcon();
+    bool isVietMode() const { return p_viet_mode ? *p_viet_mode : true; }
+    void toggleMode();
 
-private slots:
-    void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
+public slots:
     void onShowControlPanel();
     void onQuit();
 
@@ -23,14 +64,11 @@ private:
     bool* p_viet_mode;
     MainWindow* m_mainWindow;
     bool m_isGnome;
-    QSystemTrayIcon* m_trayIcon;
     QMenu* m_trayMenu;
     QAction* m_actionControlPanel;
-
     QAction* m_actionQuit;
-    
-    QIcon m_iconV;
-    QIcon m_iconE;
+
+    StatusNotifierItemAdaptor* m_dbusAdaptor = nullptr;
 };
 
 #endif // TRAYICON_H

--- a/wayland-client/src/windowtracker.cpp
+++ b/wayland-client/src/windowtracker.cpp
@@ -52,7 +52,7 @@ void WindowTracker::loadExcludedApps() {
             out << "gnome-terminal\n";
             out << "xfce4-terminal\n";
             out << "lxterminal\n";
-            out << "studio\n";
+            out << "android-studio\n";
             out << "java\n";
             file.close();
         }

--- a/wayland-client/tests/text_transaction_test.cpp
+++ b/wayland-client/tests/text_transaction_test.cpp
@@ -1,0 +1,35 @@
+#include "text_transaction.h"
+
+#include <cassert>
+#include <string>
+
+int main() {
+    const std::string word = "thê";
+    assert(composition_matches_surrounding(word, word.size(), word.size(), word));
+    assert(!composition_matches_surrounding("other", 5, 5, word));
+
+    // Regression: "thê" -> "thể" must not split a UTF-8 codepoint.
+    const std::string toned = "thể";
+    const size_t common = utf8_common_prefix_bytes(word, toned);
+    assert(common == 2);
+    assert(word.size() - common == 2);
+    assert(toned.substr(common) == "ể");
+
+    const auto plain = make_surrounding_replacement(2, word, 4, 4);
+    assert(plain.uses_surrounding);
+    assert(plain.index == -2);
+    assert(plain.length == 2);
+
+    const std::string autocomplete = "thê suggestion";
+    const auto forward = make_surrounding_replacement(2, autocomplete, 4, autocomplete.size());
+    assert(forward.uses_surrounding);
+    assert(forward.index == -2);
+    assert(forward.length == autocomplete.size() - 2);
+
+    const auto reverse = make_surrounding_replacement(2, autocomplete, autocomplete.size(), 4);
+    assert(reverse.uses_surrounding);
+    assert(reverse.index == 2 - static_cast<int32_t>(autocomplete.size()));
+    assert(reverse.length == autocomplete.size() - 2);
+
+    return 0;
+}


### PR DESCRIPTION
Chào anh Hiếu, em xin phép gửi PR đóng góp một số tính năng và bản vá tối ưu bộ gõ trên môi trường Wayland (đặc biệt là KDE Plasma 6 Wayland):

### 1. Bổ sung hỗ trợ đầy đủ VNI, VIQR và Telex 2
* Thêm hàm `Bamboo_SetInputMethod(int method)` ở tầng CGO (`bamboo_wrapper.go`) để chuyển đổi linh hoạt giữa: 1 (Telex), 2 (VNI), 3 (VIQR), 4 (Telex 2) thay vì bị cố định Telex.
* Kết nối `MainWindow::applySettings()` để cập nhật kiểu gõ xuống engine khi thay đổi cài đặt hoặc lúc khởi động ứng dụng.

### 2. Tối ưu phím tắt chuyển đổi E/V (Ctrl + Shift)
* Bổ sung cơ chế Zero-State Reset khi KWin kích hoạt/ngắt phiên gõ và tối ưu logic modifier keys, giúp bấm `Ctrl + Shift` chuyển đổi chế độ gõ ngay lập tức ở lần bấm đầu tiên (không còn độ trễ sau khi nghỉ gõ).
* Thêm cờ khóa trạng thái `g_switched` để tránh bị nhảy chế độ kép khi nhả từng phím.

### 3. Tích hợp thông báo On-Screen Display (KDE OSD)
* Tự động hiển thị popup thông báo nhỏ của KDE (`org.kde.osdService`) khi chuyển đổi chế độ gõ (`UniKey: Tiếng Việt [V]` / `UniKey: Tiếng Anh [E]`), rất tiện khi giấu icon vào trong khay hệ thống.

### 4. Sửa xung đột `WAYLAND_SOCKET` và tối ưu Event Loop
* Tách biến môi trường `WAYLAND_SOCKET` trước khi khởi tạo `QApplication` để tránh việc Qt GUI chiếm dụng socket dành riêng cho Input Method (`zwp_input_method_v1`).
* Chuyển `wl_display_dispatch` sang chạy trong background thread riêng để nhận phím tức thì và tránh bị tình trạng loop chiếm dụng CPU.

### 5. Tối ưu D-Bus StatusNotifierItem cho System Tray
* Sử dụng `QDBusServiceWatcher` theo dõi `org.kde.StatusNotifierWatcher` và thêm retry timer kép để đảm bảo icon `[V]` / `[E]` luôn tự động phục hồi khi boot máy chậm hoặc khi Plasma reload khay hệ thống.

### 6. Sửa lỗi tùy chọn đặt dấu `oà, uý` vs `òa, úy` (Bamboo Core)
* Bổ sung hàm CGO `Bamboo_SetOptions(freeMarking, modernStyle, spellCheck, autoRestore)` để truyền trạng thái checkbox từ GUI xuống Bamboo Engine.
* Ánh xạ chính xác cờ `EstdToneStyle` tương ứng với giao diện (Bỏ chọn $\rightarrow$ ra đúng kiểu truyền thống `òa, úy`; Tích chọn $\rightarrow$ ra đúng kiểu mới `oà, uý`).

### 7. Sửa lỗi VS Code bị dính gạch chân (Preedit false-positive)
* Đổi từ khóa trong danh sách `preedit_apps` từ `studio` thành `android-studio` để tránh việc bộ gõ nhận diện nhầm chuỗi con của `Visual Studio Code` thành app dòng lệnh, giúp VS Code chạy chế độ gõ trực tiếp (Direct Commit) mượt mà không có gạch chân.

### 8. Thêm script tự động hóa cài đặt `install.sh`
* Bổ sung file `install.sh` tự động dò tìm Qt6 `moc`, biên dịch lõi Go `libbamboo.a`, sinh mã Wayland protocol, liên kết binary, cài đặt desktop/icon và cấu hình KWin Virtual Keyboard chỉ với 1 lệnh duy nhất.

---
Em đã test thực tế trên KDE Plasma 6 Wayland với các app Chrome, Firefox, VS Code, Discord, v.v và bộ gõ hoạt động rất mượt mà. Anh xem qua và merge giúp em nhé!